### PR TITLE
v3.0.0: C++20 modernization, new features, and V8 13.3+ compatibility

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,8 +1,18 @@
 name: CMake
-on: [ push, pull_request ]
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   build:
+    timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         build_type: [ Release ]
@@ -24,7 +34,7 @@ jobs:
     name: '${{matrix.os}} ${{matrix.build_type}} shared_lib=${{matrix.shared_lib}} header_only=${{matrix.header_only}} v8_compress_pointers=${{matrix.v8_compress_pointers}} v8_enable_sandbox=${{matrix.v8_enable_sandbox}}'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install V8 apt 
       if: startsWith(matrix.os, 'ubuntu')
@@ -34,11 +44,18 @@ jobs:
       if: startsWith(matrix.os, 'macos')
       run: brew install v8
 
+    - name: Cache NuGet packages
+      if: startsWith(matrix.os, 'windows')
+      uses: actions/cache@v4
+      with:
+        path: ${{github.workspace}}/build/v8-v143-x64*
+        key: nuget-v8-v143-x64-${{runner.os}}
+
     - name: Install V8 nuget
       if: startsWith(matrix.os, 'windows')
       run: nuget install v8-v143-x64 -OutputDirectory ${{github.workspace}}/build
 
-    - name: Install Visual C++ 
+    - name: Install Visual C++
       if: startsWith(matrix.os, 'windows')
       uses: ilammy/msvc-dev-cmd@v1
       with:
@@ -46,7 +63,7 @@ jobs:
         vsversion: 2022
 
     - name: Install ninja-build tool
-      uses: seanmiddleditch/gha-setup-ninja@v3
+      uses: seanmiddleditch/gha-setup-ninja@v5
 
     - name: Configure CMake
       run: cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_TESTING=TRUE -DBUILD_SHARED_LIBS=${{matrix.shared_lib}} -DV8PP_HEADER_ONLY=${{matrix.header_only}} -DV8_COMPRESS_POINTERS=${{matrix.v8_compress_pointers}} -DV8_ENABLE_SANDBOX=${{matrix.v8_enable_sandbox}}
@@ -57,3 +74,11 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{matrix.build_type}} -V
+
+    - name: Upload test logs on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-logs-${{matrix.os}}-shared${{matrix.shared_lib}}-ho${{matrix.header_only}}
+        path: ${{github.workspace}}/build/Testing/
+        retention-days: 7

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -71,6 +71,20 @@ jobs:
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
 
+    - name: Debug DLL layout
+      if: startsWith(matrix.os, 'windows')
+      working-directory: ${{github.workspace}}/build
+      shell: cmd
+      run: |
+        echo === EXE location ===
+        dir /b *.exe 2>nul
+        echo === DLLs in build dir ===
+        dir /b *.dll 2>nul
+        echo === V8 DLL check ===
+        where /r . v8.dll 2>nul
+        echo === Test exe dependencies ===
+        dumpbin /dependents v8pp_test.exe 2>nul | findstr /i ".dll"
+
     - name: Test
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{matrix.build_type}} -V

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -48,8 +48,10 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       uses: actions/cache@v4
       with:
-        path: ${{github.workspace}}/build/v8-v143-x64*
-        key: nuget-v8-v143-x64-${{runner.os}}
+        path: |
+          ${{github.workspace}}/build/v8-v143-x64*
+          ${{github.workspace}}/build/v8.redist-v143-x64*
+        key: nuget-v8-v143-x64-${{runner.os}}-v2
 
     - name: Install V8 nuget
       if: startsWith(matrix.os, 'windows')

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ out/
 .vscode/
 CMakeSettings.json
 .claude/
+third_party/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ out/
 /build*/
 .vscode/
 CMakeSettings.json
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ The `convert<T>` system supports these C++ types:
 | Category | Types | V8 Representation |
 |----------|-------|-------------------|
 | Numeric | `bool`, `char`, integral, floating-point | `Boolean`, `Number` |
-| Large integers | `int64_t`, `uint64_t` (>32-bit) | `BigInt` |
+| Large integers | `int64_t`, `uint64_t` (>32-bit) | `Number` (double; accepts `BigInt` on input) |
 | Strings | `std::string`, `std::string_view`, `char const*`, wide strings | `String` |
 | Enums | any `enum` / `enum class` | `Number` (underlying type) |
 | Containers | `std::vector`, `std::list`, `std::deque`, etc. | `Array` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,296 @@
+# CLAUDE.md — v8pp Project Guide
+
+## Project Overview
+
+v8pp (v2.1.1) is a C++20 library that binds C++ functions and classes into the V8 JavaScript engine.
+It provides a fluent, type-safe API for exposing C++ types to JavaScript with automatic type conversion.
+
+- **Upstream:** https://github.com/pmed/v8pp
+- **Fork:** https://github.com/MangelSpec/v8pp
+- **License:** Boost Software License 1.0
+- **Minimum V8 version:** 9.0+ (with compatibility gates up to V8 13.3+)
+
+## Repository Structure
+
+```
+v8pp/                 # Main library source
+  *.hpp               # Public headers (class, module, context, convert, property, etc.)
+  *.ipp               # Implementation files included in header-only mode
+  *.cpp               # Compiled sources for non-header-only mode
+  config.hpp.in       # CMake-generated config header
+cmake/                # CMake modules (FindV8.cmake, Config.cmake.in)
+test/                 # Test suite (custom framework, test_*.cpp pattern)
+plugins/              # Sample plugin modules (console.cpp, file.cpp)
+examples/             # 8 numbered example projects ("01 hello world" through "08 passing wrapped objects")
+docs/                 # Documentation
+.github/workflows/    # CI (GitHub Actions: Ubuntu, macOS, Windows matrix)
+```
+
+## Build System
+
+### Requirements
+- CMake 3.12+
+- C++20 compiler (MSVC 2022, GCC, Clang)
+- V8 JavaScript engine
+
+### Key CMake Options
+| Option | Default | Description |
+|--------|---------|-------------|
+| `BUILD_SHARED_LIBS` | ON | Build as shared library |
+| `BUILD_TESTING` | OFF | Build and run tests |
+| `V8PP_HEADER_ONLY` | OFF | Header-only library mode |
+| `V8PP_ISOLATE_DATA_SLOT` | 0 | Isolate data slot for v8pp shared data |
+| `V8PP_PRETTIFY_TYPENAMES` | ON | Prettier typeid names for registered classes |
+| `V8_COMPRESS_POINTERS` | ON | V8 compressed pointers ABI |
+| `V8_ENABLE_SANDBOX` | OFF | V8 sandboxing |
+
+### Building (Windows with Ninja)
+```bash
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+cmake --build build --config Release
+```
+
+### Running Tests
+```bash
+cd build
+ctest -C Release -V
+```
+The test executable is `v8pp_test`. Run with `--version --run-tests` for the native tests.
+When `BUILD_SHARED_LIBS=ON`, JavaScript tests (`test/*.js`) also run via `--lib-path`.
+
+### V8 Installation by Platform
+- **Windows:** NuGet (`nuget install v8-v143-x64`) or vcpkg
+- **macOS:** Homebrew (`brew install v8`)
+- **Linux:** apt (`sudo apt install libv8-dev`)
+
+## Architecture & Key Abstractions
+
+### Core Types (all in namespace `v8pp`)
+- **`class_<T, Traits>`** — Binds a C++ class to V8: constructors, methods, properties, inheritance, symbol protocols, iterators
+- **`module`** — Wraps `v8::ObjectTemplate`, binds functions/variables/classes into a JS module
+- **`context`** — Manages `v8::Isolate` + `v8::Context`, provides `run_script()`, `require()`
+- **`context_store`** — Cross-context key-value store backed by a dedicated V8 context; persists values across ephemeral contexts on the same isolate
+- **`convert<T>`** — Template specializations for V8 ↔ C++ type conversion (30+ types)
+- **`property<Get, Set>`** — Compile-time getter/setter property binding
+- **`promise<T>`** — Synchronous wrapper around `v8::Promise::Resolver` with typed resolve/reject
+
+### Internal Types (in `v8pp::detail`)
+- **`object_registry<Traits>`** — Tracks wrapped C++ object lifecycles in V8 (magic number validation: `0xC1A5517F`)
+- **`external_data`** — Stores C++ data in V8 Externals (bitcast optimization for small types)
+- **`type_info`** — Lightweight compile-time RTTI using static variable addresses with integer-based IDs
+- **`call_from_v8_traits`** — Parameter extraction with default parameter support
+- **`overload_resolution`** — Runtime argument count + type dispatch for function overloading (first-match-wins)
+- **`fast_callback<FuncPtr>`** — V8 10+ Fast API callback generation via NTTP
+
+### Pointer Traits
+- `raw_ptr_traits` — Raw pointer lifecycle (`new`/`delete`)
+- `shared_ptr_traits` — `std::shared_ptr` lifecycle
+
+### Design Patterns
+- **Fluent API / Method chaining** — `.ctor<>().function().property().var()`
+- **C++20 Concepts** — Compile-time dispatch for type traits (`mapping`, `sequence`, `set_like`, `callable`, etc.)
+- **Template specialization** — Type conversion system
+- **Header-only option** — `.ipp` files are included by headers when `V8PP_HEADER_ONLY` is defined
+
+## Code Conventions
+
+### Naming
+- **Classes/types:** `snake_case` with trailing underscore for keyword conflicts (`class_<T>`)
+- **Functions:** `snake_case` (`to_v8`, `from_v8`, `throw_ex`, `set_option`)
+- **Member variables:** trailing underscore (`isolate_`, `obj_`, `impl_`)
+- **Macros/constants:** `V8PP_` prefix, `UPPER_CASE`
+- **Type aliases:** `snake_case` (`object_id`, `pointer_type`)
+- **Namespaces:** `v8pp`, `v8pp::detail`
+
+### Formatting (enforced by .clang-format)
+- **Indent:** 4 spaces (tabs for continuation)
+- **Braces:** Allman-like (open brace on new line for classes, functions, control statements)
+- **Namespaces:** compact, no indentation, no brace on new line
+- **Column limit:** none (0)
+- **Pointer alignment:** left (`int* p`, not `int *p`)
+- **Access modifiers:** flush with class keyword (offset -4)
+- **Template declarations:** always break before
+- **Short forms allowed:** short if-without-else on single line, inline-only short functions
+
+### Coding Practices
+- **Cache repeated lookups:** Extract `isolate()`, `GetCurrentContext()`, and similar
+  accessor results into local variables when used more than once in a function.
+  Avoids redundant calls and improves readability.
+- **V8 MaybeLocal/Maybe handling:** Use `ToLocalChecked()`/`FromJust()` for internal
+  operations that should never fail (crash is appropriate). Use `ToLocal()`/`FromMaybe()`
+  only where failure is genuinely reachable from user script (e.g. `ToString()` via Proxy,
+  `GetPropertyNames()` via Proxy traps) and there's a meaningful recovery path.
+- **`try_from_v8<T>`:** Exception-free conversion returning `std::optional<T>`. Use
+  instead of `is_valid()` + `from_v8()` two-step pattern for cleaner type dispatch.
+
+### Headers
+- Use `#pragma once` (no include guards)
+- Include order: standard library → V8 headers → v8pp headers
+
+### Modern C++ Features in Use
+- C++20 concepts (`mapping`, `sequence`, `set_like`, `callable`, `typed_array_element`, etc.)
+- `requires` clauses on convert specializations (replacing SFINAE `enable_if`)
+- `std::optional` for optional function parameters and `try_from_v8` results
+- `std::string_view` for string parameters
+- Fold expressions, structured bindings
+- NTTP (non-type template parameters) for Fast API callbacks
+
+## Type Conversion System
+
+The `convert<T>` system supports these C++ types:
+
+| Category | Types | V8 Representation |
+|----------|-------|-------------------|
+| Numeric | `bool`, `char`, integral, floating-point | `Boolean`, `Number` |
+| Large integers | `int64_t`, `uint64_t` (>32-bit) | `BigInt` |
+| Strings | `std::string`, `std::string_view`, `char const*`, wide strings | `String` |
+| Enums | any `enum` / `enum class` | `Number` (underlying type) |
+| Containers | `std::vector`, `std::list`, `std::deque`, etc. | `Array` |
+| Sets | `std::set`, `std::unordered_set` | `Array` |
+| Mappings | `std::map`, `std::unordered_map` | `Object` |
+| Arrays | `std::array<T,N>` | `Array` (fixed-length) |
+| Tuples | `std::tuple<Ts...>` | `Array` |
+| Pairs | `std::pair<K,V>` | `[key, value]` Array |
+| Optional | `std::optional<T>` | `T` or `undefined` |
+| Variant | `std::variant<Ts...>` | First matching type |
+| Smart ptrs | `std::shared_ptr<T>` | Wrapped object |
+| Binary | `std::vector<uint8_t>` | `ArrayBuffer` |
+| TypedArrays | `std::span<T>` (to_v8 only) | `Uint8Array`, `Float32Array`, etc. |
+| Filesystem | `std::filesystem::path` | `String` |
+| Chrono | `std::chrono::duration`, `time_point` | `Number` (milliseconds / epoch ms) |
+| V8 handles | `v8::Local<T>`, `v8::Global<T>` | Pass-through |
+| Wrapped classes | Any class bound via `class_<T>` | Wrapped object |
+| Promises | `v8pp::promise<T>` | `Promise` |
+
+## Binding Features
+
+### Class Binding (`class_<T>`)
+```cpp
+v8pp::class_<MyClass> my_class(isolate);
+my_class
+    .ctor<int, std::string>()
+    .function("method", &MyClass::method)
+    .property("prop", &MyClass::get_prop, &MyClass::set_prop)
+    .var("field", &MyClass::field)
+    .to_string_tag("MyClass")                          // Symbol.toStringTag
+    .to_primitive(&MyClass::value_of)                   // Symbol.toPrimitive
+    .iterable(&MyClass::begin, &MyClass::end);          // Symbol.iterator
+```
+
+### Function Overloading
+```cpp
+module.function("process", v8pp::overload(
+    &process_int,
+    &process_string,
+    v8pp::with_defaults(&process_opts, v8pp::defaults(42, "default"))
+));
+```
+
+### Default Parameters
+```cpp
+module.function("create", v8pp::with_defaults(
+    &create_widget,
+    v8pp::defaults(100, 200, "untitled")  // fills from right
+));
+```
+
+### V8 Fast API Callbacks (V8 10+)
+Automatically generated for functions with supported signatures (void, bool, int32_t,
+uint32_t, float, double params/returns). Registered as dual slow+fast callbacks.
+
+## V8 API Compatibility
+
+The codebase tracks V8's evolving API with version guards:
+
+```cpp
+// V8 13.3+: New string conversion API with ExternalMemoryAccounter
+#if V8_MAJOR_VERSION > 13 || (V8_MAJOR_VERSION == 13 && V8_MINOR_VERSION >= 3)
+
+// V8 12.9+: SetAccessor removed from FunctionTemplate, use SetNativeDataProperty
+// V8 12.2+: CompileModule API changes
+// V8 11.9+: Exception constructor takes options struct
+// V8 10.5+: VisitHandlesWithClassIds removed
+// V8 10.0+: Fast API callbacks available
+```
+
+When modifying V8 API calls, always check which version introduced/removed the API and add
+appropriate `#if` version guards. Test against the CI matrix (Ubuntu/macOS/Windows with
+varying V8 versions).
+
+## Safety Features
+
+- **Prototype chain depth limit** (16) in `unwrap_object` prevents infinite loops from circular prototypes
+- **Magic number validation** (`0xC1A5517F`) on `object_registry` before `static_cast` catches corruption
+- **Use-after-free protection** in `context::require()` callback via weak pointer pattern
+- **Null checks** on `unwrap_object` results in property/member accessors
+- **`try_from_v8<T>`** for exception-free conversion returning `std::optional`
+- **`ToLocal()`/`FromMaybe()`** on script-reachable paths (Proxy traps, ToString, GetPropertyNames)
+
+## Testing
+
+### Framework
+Custom lightweight framework in `test/test.hpp` (no external dependencies).
+
+### Key Test Helpers
+- `check(msg, condition)` — Assert, throws on failure
+- `check_eq(msg, obtained, expected)` — Equality check with pretty-print
+- `run_script<T>(context, code)` — Execute JS and convert result to C++ type
+
+### Test Files (22 files)
+Each test file covers one module: `test_class.cpp`, `test_convert.cpp`, `test_property.cpp`,
+`test_overload.cpp`, `test_promise.cpp`, `test_context_store.cpp`, `test_fast_api.cpp`,
+`test_symbol.cpp`, `test_adversarial.cpp`, `test_gc_stress.cpp`, `test_thread_safety.cpp`, etc.
+Tests are registered in `test/main.cpp`. The full suite runs as a single executable.
+
+## Compiler Flags
+
+### MSVC
+`/GR-` (no RTTI), `/EHsc` (structured exceptions), `/permissive-` (strict conformance),
+`/W4` (high warnings), `/wd4190` (suppress C-linkage warning), `/Zc:__cplusplus`,
+`/external:anglebrackets /external:W3` (reduced warnings for system headers)
+
+### GCC/Clang
+`-frtti`, `-fexceptions`, `-Wall -Wextra -Wpedantic`
+
+Note: macOS may need `-fno-rtti` for `context.cpp` specifically.
+
+## Git Conventions
+
+- **Commit style:** Short subject line, no trailing period, lowercase start
+- **Prefixes used:** `fix`, `add`, `use`, `improve`, or bare description
+- **Examples:**
+  - `fix const reference for _fast setters`
+  - `add get_option/set_option/set_option_data fast aliases`
+  - `Fix SetAccessor API for V8 12.9+`
+
+## Common Tasks
+
+### Adding a new type conversion
+1. Add a `convert<T>` specialization in `v8pp/convert.hpp`
+2. Implement `to_v8()` and `from_v8()` static methods
+3. Add tests in `test/test_convert.cpp`
+
+### Binding a new C++ class
+Use `v8pp::class_<T>` with the fluent API:
+```cpp
+v8pp::class_<MyClass> my_class(isolate);
+my_class
+    .ctor<int, std::string>()
+    .function("method", &MyClass::method)
+    .property("prop", &MyClass::get_prop, &MyClass::set_prop)
+    .var("field", &MyClass::field);
+```
+
+### Fixing V8 API breakage
+1. Identify the V8 version that changed the API
+2. Add `#if V8_MAJOR_VERSION > X || (V8_MAJOR_VERSION == X && V8_MINOR_VERSION >= Y)` guards
+3. Implement both old and new code paths
+4. Test across the CI matrix
+
+## CI Matrix
+
+GitHub Actions runs on push/PR with this matrix:
+- **OS:** Ubuntu, macOS, Windows
+- **Build types:** Release
+- **Variants:** shared/static × header-only/compiled
+- **V8 options:** compressed pointers and sandbox vary by platform

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(POLICY CMP0091)
 endif()
 
 project(v8pp
-	VERSION 2.1.1
+	VERSION 3.0.0
 	DESCRIPTION "Bind C++ functions and classes into V8 JavaScript engine"
 	HOMEPAGE_URL https://github.com/pmed/v8pp
 	LANGUAGES CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,13 @@ option(BUILD_TESTING "Build and run tests" OFF)
 option(BUILD_DOCUMENTATION "Build documentation" OFF)
 
 # Custom project options
-set(V8PP_HEADER_ONLY 0 CACHE BOOL "Header-only library")
+option(V8PP_HEADER_ONLY "Header-only library" OFF)
 set(V8PP_ISOLATE_DATA_SLOT 0 CACHE STRING "v8::Isolate data slot number, used in v8pp for shared data")
 set(V8PP_PLUGIN_INIT_PROC_NAME "v8pp_module_init" CACHE STRING "v8pp plugin initialization procedure name")
 set(V8PP_PLUGIN_SUFFIX ${CMAKE_SHARED_MODULE_SUFFIX} CACHE STRING "v8pp plugin filename suffix")
-set(V8PP_PRETTIFY_TYPENAMES 1 CACHE BOOL "v8pp registered classes will have prettier typeid names")
-set(V8_COMPRESS_POINTERS 1 CACHE BOOL "Use new V8 ABI with V8_COMPRESS_POINTERS and V8_31BIT_SMIS_ON_64BIT_ARCH")
-set(V8_ENABLE_SANDBOX 0 CACHE BOOL "Enable sandoxing in V8")
+option(V8PP_PRETTIFY_TYPENAMES "v8pp registered classes will have prettier typeid names" ON)
+option(V8_COMPRESS_POINTERS "Use new V8 ABI with V8_COMPRESS_POINTERS and V8_31BIT_SMIS_ON_64BIT_ARCH" ON)
+option(V8_ENABLE_SANDBOX "Enable sandboxing in V8" OFF)
 
 if(BUILD_SHARED_LIBS AND WIN32)
 	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS true)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 option(BUILD_SHARED_LIBS "Build shared library" ON)
 option(BUILD_TESTING "Build and run tests" OFF)
 option(BUILD_DOCUMENTATION "Build documentation" OFF)
+option(BUILD_BENCHMARKS "Build benchmarks" OFF)
 
 # Custom project options
 option(V8PP_HEADER_ONLY "Header-only library" OFF)
@@ -41,6 +42,10 @@ if(BUILD_TESTING)
 	enable_testing()
 	add_subdirectory(plugins)
 	add_subdirectory(test)
+endif()
+
+if(BUILD_BENCHMARKS)
+	add_subdirectory(bench)
 endif()
 
 if(BUILD_DOCUMENTATION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.12)
 
+# CMP0091: use CMAKE_MSVC_RUNTIME_LIBRARY instead of compiler flags
+if(POLICY CMP0091)
+	cmake_policy(SET CMP0091 NEW)
+endif()
+
 project(v8pp
 	VERSION 2.1.1
 	DESCRIPTION "Bind C++ functions and classes into V8 JavaScript engine"
@@ -13,6 +18,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (MSVC)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus") # enable correct __cplusplus macro
+	# static CRT when using a custom V8 monolith built with /MT
+	if(DEFINED CUSTOM_V8_LIB_PATH)
+		set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+	endif()
 endif()
 
 option(BUILD_SHARED_LIBS "Build shared library" ON)

--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ Tested on:
 - Concepts replace SFINAE for type dispatch (`mapping`, `sequence`, `set_like`, `callable`, etc.)
 - Dead V8 < 9.0 code paths removed
 
-For a detailed change-by-change analysis, see [docs/FORK_CHANGES.md](docs/FORK_CHANGES.md).
-
 ## Building and testing
 
 The library has a set of tests that can be configured, built, and run with CMake:

--- a/README.md
+++ b/README.md
@@ -1,68 +1,113 @@
-[![Build status](https://github.com/pmed/v8pp/actions/workflows/cmake.yml/badge.svg)](https://github.com/pmed/v8pp/actions/workflows/cmake.yml)
-[![NPM](https://img.shields.io/npm/v/v8pp.svg)](https://npmjs.com/package/v8pp)
-[![Join the chat at https://gitter.im/pmed/v8pp](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pmed/v8pp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pmed/v8pp)
+[![Build status](https://github.com/MangelSpec/v8pp/actions/workflows/cmake.yml/badge.svg)](https://github.com/MangelSpec/v8pp/actions/workflows/cmake.yml)
 
 # v8pp
 
-Header-only library to expose C++ classes and functions into [V8](https://developers.google.com/v8/) to use them in JavaScript code. v8pp requires a compiler with C++17 support. The library has been tested on:
+Header-only C++ library to expose C++ classes and functions into [V8](https://developers.google.com/v8/) JavaScript engine.
 
-  * Microsoft Visual C++ 2019 (Windows 10)
-  * GCC 5.4.0 (Ubuntu 16.04)
-  * Clang 5.0.0 (Ubuntu 16.04)
+This is a fork of [pmed/v8pp](https://github.com/pmed/v8pp) with performance
+optimizations, crash safety hardening, expanded type conversions, and new binding
+features. The fork is fully merged with upstream — all upstream changes are
+included here.
+
+**Requirements:** C++20 compiler, V8 9.0+
+
+Tested on:
+  * MSVC 2022 (Windows)
+  * GCC (Ubuntu)
+  * Clang (macOS)
+
+## What this fork adds
+
+**Performance**
+- Integer-based type IDs for O(1) type comparison (replaces string comparison)
+- `unordered_map` class registry for O(1) class lookup (replaces linear scan)
+- `SideEffectType` hints on function bindings for TurboFan optimization
+- Internalized V8 strings for frequently-used property names
+- `V8PP_PRETTIFY_TYPENAMES` toggle to skip string processing in production
+- Iterative subobject traversal in `object.hpp` (replaces recursion)
+- Fast aliases (`get_option_fast`, `set_option_fast`) that skip dot-path parsing
+
+**Crash safety**
+- Null checks on all `unwrap_object` results in property/member accessors
+- Prototype chain depth limit (16) in `unwrap_object` prevents infinite loops
+- Magic number validation (`0xC1A5517F`) on object registry before `static_cast`
+- Use-after-free protection in `context::require()` via weak pointer pattern
+- `try_from_v8<T>` — exception-free conversion returning `std::optional`
+- Script-reachable `ToLocalChecked` paths replaced with `ToLocal` + proper error handling
+- `FromJust` → `FromMaybe` on script-reachable paths
+- Member pointer bitcast exclusion (prevents V8 debug assertion crash)
+
+**New binding features**
+- Function overloading with `v8pp::overload()`
+- Default parameters with `v8pp::defaults()`
+- V8 Fast API callbacks (auto-generated for compatible signatures, V8 10+)
+- `const_property` — evaluated once at wrap time, stored as read-only own property
+- `v8pp::promise<T>` — synchronous wrapper around `v8::Promise::Resolver`
+- Symbol protocol support (`Symbol.toStringTag`, `Symbol.toPrimitive`, `Symbol.iterator`)
+- Iterator protocol (`class_<T>::iterable(begin, end)` for `for...of` support)
+- `context_store` — cross-context key-value persistence on the same isolate
+
+**Expanded type conversions**
+- `int64_t`/`uint64_t` ↔ `BigInt`
+- `std::span<T>` → TypedArrays (`Uint8Array`, `Float32Array`, etc.)
+- `std::vector<uint8_t>` ↔ `ArrayBuffer`
+- `std::set`/`std::unordered_set` ↔ `Array`
+- `std::pair<K,V>` ↔ two-element `Array`
+- `std::filesystem::path` ↔ `String`
+- `std::chrono::duration`/`time_point` ↔ `Number` (milliseconds)
+- `std::monostate` in `std::variant` for `null`/`undefined`
+
+**V8 API compatibility**
+- V8 12.9+: `SetNativeDataProperty` on `InstanceTemplate` (replaces removed `SetAccessor`)
+- V8 13.3+: `ExternalMemoryAccounter` for string conversion
+- Fixed constructor object identity (`wrap_this` uses `args.This()` instead of creating a second object)
+- All bindings registered on `js_function_template` (fixes inheritance and `super` calls)
+
+**C++20 modernization**
+- Concepts replace SFINAE for type dispatch (`mapping`, `sequence`, `set_like`, `callable`, etc.)
+- Dead V8 < 9.0 code paths removed
+
+For a detailed change-by-change analysis, see [docs/FORK_CHANGES.md](docs/FORK_CHANGES.md).
 
 ## Building and testing
 
 The library has a set of tests that can be configured, built, and run with CMake:
 
 ```console
-~/v8pp$ mkdir out; cd out
-~/v8pp/out$ cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ..
-~/v8pp/out$ make
-~/v8pp/out$ ctest -V
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+cmake --build build --config Release
+cd build && ctest -C Release -V
 ```
 
-The full list of project options can be listed with cmake command:
+### V8 installation
 
-```console
-~/v8pp/out$ cmake -LH ..
-```
+| Platform | Command |
+|----------|---------|
+| Windows  | `nuget install v8-v143-x64` or vcpkg |
+| macOS    | `brew install v8` |
+| Linux    | `sudo apt install libv8-dev` |
 
-Some of them could be:
+### CMake options
 
-> // Build documentation
-> BUILD_DOCUMENTATION:BOOL=OFF
->
-> // Build shared library
-> BUILD_SHARED_LIBS:BOOL=ON
->
-> // Build and run tests
-> BUILD_TESTING:BOOL=OFF
->
-> // Header-only library
-> V8PP_HEADER_ONLY:BOOL=0
->
-> // v8::Isolate data slot number, used in v8pp for shared data
-> V8PP_ISOLATE_DATA_SLOT:STRING=0
->
-> // v8pp plugin initialization procedure name
-> V8PP_PLUGIN_INIT_PROC_NAME:STRING=v8pp_module_init
->
-> // v8pp plugin filename suffix
-> V8PP_PLUGIN_SUFFIX:STRING=.dylib
->
-> // Use new V8 ABI with V8_COMPRESS_POINTERS and V8_31BIT_SMIS_ON_64BIT_ARCH
-> V8_COMPRESS_POINTERS:BOOL=ON
-
+| Option | Default | Description |
+|--------|---------|-------------|
+| `BUILD_SHARED_LIBS` | ON | Build as shared library |
+| `BUILD_TESTING` | OFF | Build and run tests |
+| `V8PP_HEADER_ONLY` | 0 | Header-only library mode |
+| `V8PP_ISOLATE_DATA_SLOT` | 0 | Isolate data slot for v8pp shared data |
+| `V8PP_PRETTIFY_TYPENAMES` | 1 | Prettier type names (disable for max performance) |
+| `V8_COMPRESS_POINTERS` | ON | V8 compressed pointers ABI |
+| `V8_ENABLE_SANDBOX` | OFF | V8 sandboxing |
 
 ## Binding example
 
-v8pp supports V8 versions after 6.3 with `v8::Isolate` usage in API. There are 2 targets for binding:
+v8pp provides two main binding targets:
 
   * `v8pp::module`, a wrapper class around `v8::ObjectTemplate`
   * `v8pp::class_`, a template class wrapper around `v8::FunctionTemplate`
 
-Both of them require a pointer to `v8::Isolate` instance. They allows to bind from C++ code such items as variables, functions, constants with a function `set(name, item)`:
+Both require a pointer to `v8::Isolate`. They allow binding variables, functions,
+constants, and properties with a fluent `.set(name, item)` API:
 
 ```c++
 v8::Isolate* isolate;
@@ -82,26 +127,18 @@ struct X
 // bind free variables and functions
 v8pp::module mylib(isolate);
 mylib
-    // set read-only attribute
     .const_("PI", 3.1415)
-    // set variable available in JavaScript with name `var`
     .var("var", var)
-    // set function get_var as `fun`
     .function("fun", &get_var)
-    // set property `prop` with getter get_var() and setter set_var()
     .property("prop", get_var, set_var);
 
 // bind class
 v8pp::class_<X> X_class(isolate);
 X_class
-    // specify X constructor signature
     .ctor<int, bool>()
-    // bind variable
     .var("var", &X::var)
-    // bind function
     .function("fun", &X::set)
-    // bind read-only property
-    .property("prop",&X::get);
+    .property("prop", &X::get);
 
 // set class into the module template
 mylib.class_("X", X_class);
@@ -118,37 +155,122 @@ var x = new mylib.X(1, true);
 mylib.prop = x.prop + x.fun();
 ```
 
-## Node.js and io.js addons
-
-The library is suitable to make [Node.js](http://nodejs.org/) and [io.js](https://iojs.org/) addons. See [addons](docs/addons.md) document.
+## Function overloading
 
 ```c++
+v8pp::module m(isolate);
+m.function("process", v8pp::overload(
+    &process_int,
+    &process_string,
+    v8pp::with_defaults(&process_opts, v8pp::defaults(42, "default"))
+));
+```
 
+## Default parameters
+
+```c++
+v8pp::module m(isolate);
+m.function("create", v8pp::with_defaults(
+    &create_widget,
+    v8pp::defaults(100, 200, "untitled")  // fills from right
+));
+```
+
+## Symbol protocols and iterators
+
+```c++
+v8pp::class_<MyClass> my_class(isolate);
+my_class
+    .ctor<int>()
+    .to_string_tag("MyClass")                      // Symbol.toStringTag
+    .to_primitive(&MyClass::value_of)               // Symbol.toPrimitive
+    .iterable(&MyClass::begin, &MyClass::end);      // Symbol.iterator → for...of
+```
+
+## Promise support
+
+```c++
+v8pp::promise<int> p(isolate);
+v8::Local<v8::Promise> js_promise = p.promise();  // return this to JS
+
+// later, from C++:
+p.resolve(42);
+// or: p.reject("something went wrong");
+```
+
+## Type conversion table
+
+| C++ Type | V8 / JS Type |
+|----------|-------------|
+| `bool`, integral, floating-point | `Boolean`, `Number` |
+| `int64_t`, `uint64_t` | `BigInt` |
+| `std::string`, `std::string_view`, `char const*` | `String` |
+| `enum` / `enum class` | `Number` |
+| `std::vector`, `std::list`, `std::deque`, etc. | `Array` |
+| `std::set`, `std::unordered_set` | `Array` |
+| `std::map`, `std::unordered_map` | `Object` |
+| `std::array<T,N>` | `Array` |
+| `std::tuple<Ts...>` | `Array` |
+| `std::pair<K,V>` | `[key, value]` |
+| `std::optional<T>` | `T` or `undefined` |
+| `std::variant<Ts...>` | First matching type |
+| `std::shared_ptr<T>` | Wrapped object |
+| `std::vector<uint8_t>` | `ArrayBuffer` |
+| `std::span<T>` | TypedArray (`Uint8Array`, `Float32Array`, etc.) |
+| `std::filesystem::path` | `String` |
+| `std::chrono::duration` | `Number` (milliseconds) |
+| `std::chrono::time_point` | `Number` (epoch ms) |
+| `v8::Local<T>`, `v8::Global<T>` | Pass-through |
+| Any `class_<T>`-bound class | Wrapped object |
+| `v8pp::promise<T>` | `Promise` |
+
+## Class binding
+
+```c++
+v8pp::class_<MyClass> my_class(isolate);
+my_class
+    .ctor<int, std::string>()
+    .function("method", &MyClass::method)
+    .property("prop", &MyClass::get_prop, &MyClass::set_prop)
+    .const_property("id", &MyClass::id)     // evaluated once, read-only
+    .var("field", &MyClass::field)
+    .const_("MAX", 100);
+```
+
+## Node.js and io.js addons
+
+The library is suitable to make [Node.js](http://nodejs.org/) addons. See [addons](docs/addons.md) document.
+
+```c++
 void RegisterModule(v8::Local<v8::Object> exports)
 {
     v8pp::module addon(v8::Isolate::GetCurrent());
 
-    // set bindings...
     addon
         .function("fun", &function)
         .class_("cls", my_class)
         ;
 
-    // set bindings as exports object prototype
     exports->SetPrototype(addon.new_instance());
 }
 ```
 
-## v8pp also provides
+## Plugins
 
-* `v8pp` - a static library to add several global functions (load/require to the v8 JavaScript context. `require()` is a system for loading plugins from shared libraries.
-* `test` - A binary for running JavaScript files in a context which has v8pp module loading functions provided.
-
-## v8pp module example
+v8pp provides a `require()` system for loading plugins from shared libraries:
 
 ```c++
-#include <iostream>
+#include <v8pp/context.hpp>
 
+v8pp::context context;
+context.set_lib_path("path/to/plugins/lib");
+v8::HandleScope scope(context.isolate());
+context.run_file("some_file.js");
+```
+
+### Plugin example
+
+```c++
 #include <v8pp/module.hpp>
 
 namespace console {
@@ -156,12 +278,11 @@ namespace console {
 void log(v8::FunctionCallbackInfo<v8::Value> const& args)
 {
     v8::HandleScope handle_scope(args.GetIsolate());
-
     for (int i = 0; i < args.Length(); ++i)
     {
         if (i > 0) std::cout << ' ';
         v8::String::Utf8Value str(args[i]);
-        std::cout <<  *str;
+        std::cout << *str;
     }
     std::cout << std::endl;
 }
@@ -174,227 +295,45 @@ v8::Local<v8::Value> init(v8::Isolate* isolate)
 }
 
 } // namespace console
-```
 
-## Turning a v8pp module into a v8pp plugin
-
-```c++
 V8PP_PLUGIN_INIT(v8::Isolate* isolate)
 {
     return console::init(isolate);
 }
 ```
 
-## v8pp class binding example
+## External C++ objects
 
 ```c++
-#include <v8pp/module.hpp>
-#include <v8pp/class.hpp>
+// Reference external — C++ object outlives JavaScript wrapper
+v8::Local<v8::Value> val = v8pp::class_<my_class>::reference_external(
+    isolate, &my_class::instance());
 
-#include <fstream>
-
-namespace file {
-
-bool rename(char const* src, char const* dest)
-{
-    return std::rename(src, dest) == 0;
-}
-
-class file_base
-{
-public:
-    bool is_open() const { return stream_.is_open(); }
-    bool good() const { return stream_.good(); }
-    bool eof() const { return stream_.eof(); }
-    void close() { stream_.close(); }
-
-protected:
-    std::fstream stream_;
-};
-
-class file_writer : public file_base
-{
-public:
-    explicit file_writer(v8::FunctionCallbackInfo<v8::Value> const& args)
-    {
-        if (args.Length() == 1)
-        {
-            v8::String::Utf8Value str(args[0]);
-            open(*str);
-        }
-    }
-
-    bool open(char const* path)
-    {
-        stream_.open(path, std::ios_base::out);
-        return stream_.good();
-    }
-
-    void print(v8::FunctionCallbackInfo<v8::Value> const& args)
-    {
-        v8::HandleScope scope(args.GetIsolate());
-
-        for (int i = 0; i < args.Length(); ++i)
-        {
-            if (i > 0) stream_ << ' ';
-            v8::String::Utf8Value str(args[i]);
-            stream_ << *str;
-        }
-    }
-
-    void println(v8::FunctionCallbackInfo<v8::Value> const& args)
-    {
-        print(args);
-        stream_ << std::endl;
-    }
-};
-
-class file_reader : public file_base
-{
-public:
-    explicit file_reader(char const* path)
-    {
-        open(path);
-    }
-
-    bool open(const char* path)
-    {
-        stream_.open(path, std::ios_base::in);
-        return stream_.good();
-    }
-
-    v8::Local<v8::Value> getline(v8::Isolate* isolate)
-    {
-        if ( stream_.good() && ! stream_.eof())
-        {
-            std::string line;
-            std::getline(stream_, line);
-            return v8pp::to_v8(isolate, line);
-        }
-        else
-        {
-            return v8::Undefined(isolate);
-        }
-    }
-};
-
-v8::Local<v8::Value> init(v8::Isolate* isolate)
-{
-    v8::EscapableHandleScope scope(isolate);
-
-    // file_base binding, no .ctor() specified, object creation disallowed in JavaScript
-    v8pp::class_<file_base> file_base_class(isolate);
-    file_base_class
-        .function("close", &file_base::close)
-        .function("good", &file_base::good)
-        .function("is_open", &file_base::is_open)
-        .function("eof", &file_base::eof)
-        ;
-
-    // .ctor<> template arguments declares types of file_writer constructor
-    // file_writer inherits from file_base_class
-    v8pp::class_<file_writer> file_writer_class(isolate);
-    file_writer_class
-        .ctor<v8::FunctionCallbackInfo<v8::Value> const&>()
-        .inherit<file_base>()
-        .function("open", &file_writer::open)
-        .function("print", &file_writer::print)
-        .function("println", &file_writer::println)
-        ;
-
-    // .ctor<> template arguments declares types of file_reader constructor.
-    // file_base inherits from file_base_class
-    v8pp::class_<file_reader> file_reader_class(isolate);
-    file_reader_class
-        .ctor<char const*>()
-        .inherit<file_base>()
-        .function("open", &file_reader::open)
-        .function("getln", &file_reader::getline)
-        ;
-
-    // Create a module to add classes and functions to and return a
-    // new instance of the module to be embedded into the v8 context
-    v8pp::module m(isolate);
-    m.function("rename", &rename)
-     .class_("writer", file_writer_class)
-     .class_("reader", file_reader_class)
-        ;
-
-    return scope.Escape(m.new_instance());
-}
-
-} // namespace file
-
-V8PP_PLUGIN_INIT(v8::Isolate* isolate)
-{
-    return file::init(isolate);
-}
-```
-
-## Creating a v8 context capable of using require() function
-
-```c++
-#include <v8pp/context.hpp>
-
-v8pp::context context;
-context.set_lib_path("path/to/plugins/lib");
-// script can now use require() function. An application
-// that uses v8pp::context must link against v8pp library.
-v8::HandleScope scope(context.isolate());
-context.run_file("some_file.js");
-```
-
-## Using require() from JavaScript
-
-```javascript
-// Load the file module from the class binding example and the
-// console module.
-var file    = require('file'),
-    console = require('console')
-
-var writer = new file.writer("file")
-if (writer.is_open()) {
-    writer.println("some text")
-    writer.close()
-    if (! file.rename("file", "newfile"))
-        console.log("could not rename file")
-}
-else console.log("could not open `file'")
-
-console.log("exit")
-```
-
-## Create a handle to an externally referenced C++ class.
-
-```c++
-// Memory for C++ class will remain when JavaScript object is deleted.
-// Useful for classes you only wish to inject.
-typedef v8pp::class_<my_class> my_class_wrapper;
-v8::Local<v8::Value> val = my_class_wrapper::reference_external(isolate, &my_class::instance());
-// Assuming my_class::instance() returns reference to class
-```
-
-## Import externally created C++ class into v8pp.
-
-```c++
-// Memory for c++ object will be reclaimed by JavaScript using "delete" when
-// JavaScript class is deleted.
-typedef v8pp::class_<my_class> my_class_wrapper;
-v8::Local<v8::Value> val = my_class_wrapper::import_external(isolate, new my_class);
+// Import external — JavaScript takes ownership via pointers / shared_ptr
+v8::Local<v8::Value> val = v8pp::class_<my_class>::import_external(
+    isolate, new my_class);
 ```
 
 ## Compile-time configuration
 
-The library uses several preprocessor macros, defined in `v8pp/config.hpp` file:
+Defined in `v8pp/config.hpp`:
 
-  * `V8PP_ISOLATE_DATA_SLOT` - A v8::Isolate data slot number, used to store v8pp internal data
-  * `V8PP_PLUGIN_INIT_PROC_NAME` - Plugin initialization procedure name that should be exported from a v8pp plugin.
-  * `V8PP_PLUGIN_SUFFIX` - Plugin filename suffix that would be added if the plugin name used in `require()` doesn't end with it.
-  * `V8PP_HEADER_ONLY` - Use header-only implemenation, enabled by default.
+  * `V8PP_ISOLATE_DATA_SLOT` — v8::Isolate data slot for v8pp internal data
+  * `V8PP_PLUGIN_INIT_PROC_NAME` — Plugin initialization procedure name
+  * `V8PP_PLUGIN_SUFFIX` — Plugin filename suffix for `require()`
+  * `V8PP_HEADER_ONLY` — Header-only mode (default)
+  * `V8PP_PRETTIFY_TYPENAMES` — Pretty type names for debugging (disable for performance)
 
-## v8pp alternatives
+## License
+
+[Boost Software License 1.0](LICENSE.md)
+
+## Upstream
+
+[pmed/v8pp](https://github.com/pmed/v8pp) — original project by [pmed](https://github.com/pmed)
+
+## Alternatives
 
 * [nbind](https://github.com/charto/nbind)
-* [vu8](https://github.com/tsa/vu8), abandoned
-* [v8-juice](http://code.google.com/p/v8-juice/), abandoned
-* Script bindng in [cpgf](https://github.com/cpgf/cpgf)
+* [vu8](https://github.com/tsa/vu8)
+* [v8-juice](http://code.google.com/p/v8-juice/)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,0 +1,20 @@
+# benchmark target
+
+add_executable(v8pp_bench
+	main.cpp
+	bench.hpp
+	bench_convert.cpp
+	bench_call.cpp
+	bench_class.cpp
+	bench_property.cpp
+)
+
+if(V8PP_HEADER_ONLY)
+	target_sources(v8pp_bench PRIVATE ${PROJECT_SOURCE_DIR}/v8pp/context.cpp)
+	if(APPLE)
+		# see v8pp/CMakeLists.txt
+		set_source_files_properties(${PROJECT_SOURCE_DIR}/v8pp/context.cpp PROPERTIES COMPILE_FLAGS -fno-rtti)
+	endif()
+endif()
+
+target_link_libraries(v8pp_bench PRIVATE v8pp ${CMAKE_DL_LIBS})

--- a/bench/bench.hpp
+++ b/bench/bench.hpp
@@ -1,0 +1,144 @@
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "v8pp/context.hpp"
+#include "v8pp/convert.hpp"
+
+namespace v8pp::bench {
+
+struct result
+{
+    std::string name;
+    size_t iterations;
+    std::vector<double> samples_ns; // per-iteration time in nanoseconds
+
+    double min_ns() const
+    {
+        return *std::min_element(samples_ns.begin(), samples_ns.end());
+    }
+
+    double max_ns() const
+    {
+        return *std::max_element(samples_ns.begin(), samples_ns.end());
+    }
+
+    double mean_ns() const
+    {
+        return std::accumulate(samples_ns.begin(), samples_ns.end(), 0.0)
+             / static_cast<double>(samples_ns.size());
+    }
+
+    double median_ns() const
+    {
+        std::vector<double> sorted = samples_ns;
+        std::sort(sorted.begin(), sorted.end());
+        size_t n = sorted.size();
+        if (n % 2 == 0)
+            return (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0;
+        return sorted[n / 2];
+    }
+
+    double ops_per_sec() const
+    {
+        double med = median_ns();
+        return med > 0.0 ? 1'000'000'000.0 / med : 0.0;
+    }
+};
+
+/// Run a benchmark: warmup, then collect timing samples.
+/// Each sample times `iterations_per_sample` calls of `fn`.
+inline result run(std::string_view name,
+                  size_t iterations_per_sample,
+                  size_t sample_count,
+                  std::function<void()> const& fn)
+{
+    // Warmup: 10% of iterations, minimum 10
+    size_t warmup = std::max<size_t>(iterations_per_sample / 10, 10);
+    for (size_t i = 0; i < warmup; ++i)
+    {
+        fn();
+    }
+
+    result r;
+    r.name = name;
+    r.iterations = iterations_per_sample;
+    r.samples_ns.reserve(sample_count);
+
+    for (size_t s = 0; s < sample_count; ++s)
+    {
+        auto start = std::chrono::steady_clock::now();
+        for (size_t i = 0; i < iterations_per_sample; ++i)
+        {
+            fn();
+        }
+        auto end = std::chrono::steady_clock::now();
+
+        double elapsed_ns = std::chrono::duration<double, std::nano>(end - start).count();
+        r.samples_ns.push_back(elapsed_ns / static_cast<double>(iterations_per_sample));
+    }
+
+    return r;
+}
+
+/// Convenience: benchmark a JS script executed via context.run_script()
+inline result run_script_bench(std::string_view name,
+                               v8pp::context& ctx,
+                               std::string_view script,
+                               size_t iterations = 10000,
+                               size_t samples = 20)
+{
+    v8::Isolate* isolate = ctx.isolate();
+    return run(name, iterations, samples, [&]()
+    {
+        v8::HandleScope scope(isolate);
+        v8::TryCatch try_catch(isolate);
+        ctx.run_script(script);
+    });
+}
+
+inline void print_result(result const& r)
+{
+    auto fmt_time = [](double ns) -> std::string
+    {
+        char buf[64];
+        if (ns < 1'000.0)
+            std::snprintf(buf, sizeof(buf), "%.1f ns", ns);
+        else if (ns < 1'000'000.0)
+            std::snprintf(buf, sizeof(buf), "%.2f us", ns / 1'000.0);
+        else
+            std::snprintf(buf, sizeof(buf), "%.2f ms", ns / 1'000'000.0);
+        return buf;
+    };
+
+    auto fmt_ops = [](double ops) -> std::string
+    {
+        char buf[64];
+        if (ops >= 1'000'000.0)
+            std::snprintf(buf, sizeof(buf), "%.2f M", ops / 1'000'000.0);
+        else if (ops >= 1'000.0)
+            std::snprintf(buf, sizeof(buf), "%.2f K", ops / 1'000.0);
+        else
+            std::snprintf(buf, sizeof(buf), "%.0f", ops);
+        return buf;
+    };
+
+    std::cout << std::left << std::setw(45) << r.name
+              << "  median=" << std::setw(12) << fmt_time(r.median_ns())
+              << "  min=" << std::setw(12) << fmt_time(r.min_ns())
+              << "  max=" << std::setw(12) << fmt_time(r.max_ns())
+              << "  ops/s=" << fmt_ops(r.ops_per_sec())
+              << "\n";
+}
+
+} // namespace v8pp::bench

--- a/bench/bench_call.cpp
+++ b/bench/bench_call.cpp
@@ -1,0 +1,79 @@
+#include <string>
+
+#include "v8pp/context.hpp"
+#include "v8pp/module.hpp"
+#include "v8pp/fast_api.hpp"
+#include "bench.hpp"
+
+namespace {
+
+void noop() {}
+int noop_return() { return 0; }
+int32_t add_ints(int32_t a, int32_t b) { return a + b; }
+std::string concat(std::string const& a, std::string const& b) { return a + b; }
+double compute(double a, double b, double c) { return a * b + c; }
+
+} // anonymous namespace
+
+void bench_call()
+{
+    v8pp::context context;
+    v8::Isolate* isolate = context.isolate();
+    v8::HandleScope scope(isolate);
+
+    using namespace v8pp::bench;
+    size_t const N = 10000;
+    size_t const S = 20;
+
+    // Bind functions into global scope
+    context.function("noop", &noop);
+    context.function("noop_return", &noop_return);
+    context.function("add_ints", &add_ints);
+    context.function("concat", &concat);
+    context.function("compute", &compute);
+
+#if V8_MAJOR_VERSION >= 10
+    context.function("fast_add", v8pp::fast_fn<&add_ints>);
+#endif
+
+    // --- Baseline: empty function call overhead ---
+    print_result(run_script_bench("JS->C++ void noop()",
+        context, "noop()", N, S));
+
+    print_result(run_script_bench("JS->C++ int noop_return()",
+        context, "noop_return()", N, S));
+
+    // --- Primitive argument passing ---
+    print_result(run_script_bench("JS->C++ add_ints(int, int)",
+        context, "add_ints(1, 2)", N, S));
+
+#if V8_MAJOR_VERSION >= 10
+    // --- Fast API vs slow path ---
+    print_result(run_script_bench("JS->C++ fast_add(int, int)",
+        context, "fast_add(1, 2)", N, S));
+#endif
+
+    // --- String arguments ---
+    print_result(run_script_bench("JS->C++ concat(str, str)",
+        context, "concat('hello', ' world')", N, S));
+
+    // --- Multiple arguments ---
+    print_result(run_script_bench("JS->C++ compute(dbl, dbl, dbl)",
+        context, "compute(1.5, 2.5, 3.5)", N, S));
+
+    // --- Tight loop from JS (V8 JIT) ---
+    context.function("add", &add_ints);
+    print_result(run_script_bench("JS loop: 1000x add_ints",
+        context, "var s = 0; for (var i = 0; i < 1000; i++) s = add(s, 1); s",
+        N / 100, S));
+
+    // --- Module-scoped function call ---
+    {
+        v8pp::module m(isolate);
+        m.function("add", &add_ints);
+        context.module("mod", m);
+
+        print_result(run_script_bench("JS->C++ mod.add(int, int)",
+            context, "mod.add(1, 2)", N, S));
+    }
+}

--- a/bench/bench_class.cpp
+++ b/bench/bench_class.cpp
@@ -1,0 +1,133 @@
+#include <cmath>
+
+#include "v8pp/class.hpp"
+#include "v8pp/context.hpp"
+#include "v8pp/module.hpp"
+#include "bench.hpp"
+
+namespace {
+
+struct Point
+{
+    double x, y;
+    Point() : x(0), y(0) {}
+    Point(double x, double y) : x(x), y(y) {}
+    double length() const { return std::sqrt(x * x + y * y); }
+    double dot(Point const& other) const { return x * other.x + y * other.y; }
+    void translate(double dx, double dy) { x += dx; y += dy; }
+};
+
+struct Base
+{
+    int value;
+    explicit Base(int v) : value(v) {}
+    int get_value() const { return value; }
+};
+
+struct Derived : Base
+{
+    int extra;
+    explicit Derived(int v) : Base(v), extra(v * 2) {}
+    int get_extra() const { return extra; }
+};
+
+} // anonymous namespace
+
+void bench_class()
+{
+    v8pp::context context;
+    v8::Isolate* isolate = context.isolate();
+    v8::HandleScope scope(isolate);
+
+    using namespace v8pp::bench;
+    size_t const N = 10000;
+    size_t const S = 20;
+
+    // --- Point class: construction, methods, var access ---
+    {
+        v8pp::class_<Point> point_class(isolate);
+        point_class
+            .ctor<double, double>()
+            .var("x", &Point::x)
+            .var("y", &Point::y)
+            .function("length", &Point::length)
+            .function("dot", &Point::dot)
+            .function("translate", &Point::translate);
+        context.class_("Point", point_class);
+
+        // Object construction from JS
+        print_result(run_script_bench("class: new Point(x,y)",
+            context, "var p = new Point(3.0, 4.0); p.x", N, S));
+
+        // Set up a persistent object for method/var benchmarks
+        context.run_script("var pt = new Point(3.0, 4.0)");
+
+        print_result(run_script_bench("class: pt.length()",
+            context, "pt.length()", N, S));
+
+        print_result(run_script_bench("class: pt.dot(pt)",
+            context, "pt.dot(pt)", N, S));
+
+        print_result(run_script_bench("class: pt.translate(dx,dy)",
+            context, "pt.translate(0.1, 0.1); pt.x", N, S));
+
+        // Direct member variable access via var()
+        print_result(run_script_bench("class: pt.x (get var)",
+            context, "pt.x", N, S));
+
+        print_result(run_script_bench("class: pt.x = val (set var)",
+            context, "pt.x = 5.0", N, S));
+    }
+
+    // --- C++ side wrap/unwrap ---
+    {
+        v8pp::class_<Base> base_class(isolate);
+        base_class
+            .ctor<int>()
+            .function("get_value", &Base::get_value);
+        context.class_("Base", base_class);
+
+        // Measure wrap cost from C++ side
+        print_result(run("class: wrap_object (C++ side)", N, S, [&]()
+        {
+            v8::HandleScope hs(isolate);
+            Base* obj = new Base(42);
+            v8pp::class_<Base>::reference_external(isolate, obj);
+            v8pp::class_<Base>::unreference_external(isolate, obj);
+            delete obj;
+        }));
+
+        // Measure unwrap from a JS value
+        context.run_script("var b = new Base(42)");
+        v8::Local<v8::Value> b_val = context.run_script("b");
+        print_result(run("class: unwrap_object (C++ side)", N, S, [&]()
+        {
+            v8pp::class_<Base>::unwrap_object(isolate, b_val);
+        }));
+    }
+
+    // --- Inheritance ---
+    {
+        v8pp::class_<Derived> derived_class(isolate);
+        derived_class
+            .ctor<int>()
+            .inherit<Base>()
+            .function("get_extra", &Derived::get_extra);
+        context.class_("Derived", derived_class);
+
+        print_result(run_script_bench("class: new Derived (with inherit)",
+            context, "var d = new Derived(10); d.get_value()", N, S));
+
+        context.run_script("var dd = new Derived(10)");
+        print_result(run_script_bench("class: base method via derived",
+            context, "dd.get_value()", N, S));
+    }
+
+    // --- Bulk object creation (GC pressure) ---
+    print_result(run("class: 100x new Point from JS", N / 100, S, [&]()
+    {
+        v8::HandleScope hs(isolate);
+        v8::TryCatch try_catch(isolate);
+        context.run_script("for (var i = 0; i < 100; i++) new Point(i, i)");
+    }));
+}

--- a/bench/bench_convert.cpp
+++ b/bench/bench_convert.cpp
@@ -1,0 +1,120 @@
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "v8pp/context.hpp"
+#include "v8pp/convert.hpp"
+#include "bench.hpp"
+
+void bench_convert()
+{
+    v8pp::context context;
+    v8::Isolate* isolate = context.isolate();
+    v8::HandleScope scope(isolate);
+
+    using namespace v8pp::bench;
+    size_t const N = 50000;
+    size_t const S = 20;
+
+    // --- Primitive to_v8 ---
+    print_result(run("int32 to_v8", N, S, [&]()
+    {
+        v8::HandleScope hs(isolate);
+        v8pp::to_v8(isolate, 42);
+    }));
+
+    print_result(run("double to_v8", N, S, [&]()
+    {
+        v8::HandleScope hs(isolate);
+        v8pp::to_v8(isolate, 3.14);
+    }));
+
+    print_result(run("bool to_v8", N, S, [&]()
+    {
+        v8::HandleScope hs(isolate);
+        v8pp::to_v8(isolate, true);
+    }));
+
+    // --- Primitive from_v8 ---
+    v8::Local<v8::Value> v8_int = v8pp::to_v8(isolate, 42);
+    print_result(run("int32 from_v8", N, S, [&]()
+    {
+        v8pp::from_v8<int>(isolate, v8_int);
+    }));
+
+    v8::Local<v8::Value> v8_double = v8pp::to_v8(isolate, 3.14);
+    print_result(run("double from_v8", N, S, [&]()
+    {
+        v8pp::from_v8<double>(isolate, v8_double);
+    }));
+
+    v8::Local<v8::Value> v8_bool = v8pp::to_v8(isolate, true);
+    print_result(run("bool from_v8", N, S, [&]()
+    {
+        v8pp::from_v8<bool>(isolate, v8_bool);
+    }));
+
+    // --- String conversions ---
+    print_result(run("short string to_v8 (5 chars)", N, S, [&]()
+    {
+        v8::HandleScope hs(isolate);
+        v8pp::to_v8(isolate, "hello");
+    }));
+
+    print_result(run("long string to_v8 (100 chars)", N, S, [&]()
+    {
+        v8::HandleScope hs(isolate);
+        v8pp::to_v8(isolate, std::string(100, 'x'));
+    }));
+
+    v8::Local<v8::Value> v8_str = v8pp::to_v8(isolate, "hello world");
+    print_result(run("string from_v8", N, S, [&]()
+    {
+        v8pp::from_v8<std::string>(isolate, v8_str);
+    }));
+
+    // --- Container conversions ---
+    std::vector<int> vec100(100, 42);
+    print_result(run("vector<int>(100) to_v8", N / 10, S, [&]()
+    {
+        v8::HandleScope hs(isolate);
+        v8pp::to_v8(isolate, vec100);
+    }));
+
+    v8::Local<v8::Value> v8_arr = v8pp::to_v8(isolate, vec100);
+    print_result(run("vector<int>(100) from_v8", N / 10, S, [&]()
+    {
+        v8pp::from_v8<std::vector<int>>(isolate, v8_arr);
+    }));
+
+    // --- Map conversion ---
+    std::map<std::string, int> map10;
+    for (int i = 0; i < 10; ++i) map10["key" + std::to_string(i)] = i;
+    print_result(run("map<string,int>(10) to_v8", N / 10, S, [&]()
+    {
+        v8::HandleScope hs(isolate);
+        v8pp::to_v8(isolate, map10);
+    }));
+
+    v8::Local<v8::Value> v8_map = v8pp::to_v8(isolate, map10);
+    print_result(run("map<string,int>(10) from_v8", N / 10, S, [&]()
+    {
+        v8pp::from_v8<std::map<std::string, int>>(isolate, v8_map);
+    }));
+
+    // --- std::optional ---
+    std::optional<int> opt_val = 42;
+    print_result(run("optional<int> to_v8 (engaged)", N, S, [&]()
+    {
+        v8::HandleScope hs(isolate);
+        v8pp::to_v8(isolate, opt_val);
+    }));
+
+    std::optional<int> opt_empty;
+    print_result(run("optional<int> to_v8 (empty)", N, S, [&]()
+    {
+        v8::HandleScope hs(isolate);
+        v8pp::to_v8(isolate, opt_empty);
+    }));
+}

--- a/bench/bench_property.cpp
+++ b/bench/bench_property.cpp
@@ -1,0 +1,73 @@
+#include <string>
+
+#include "v8pp/class.hpp"
+#include "v8pp/context.hpp"
+#include "v8pp/property.hpp"
+#include "bench.hpp"
+
+namespace {
+
+struct Widget
+{
+    int width_ = 100;
+    int height_ = 200;
+    std::string name_ = "widget";
+
+    int get_width() const { return width_; }
+    void set_width(int w) { width_ = w; }
+
+    int get_height() const { return height_; }
+    void set_height(int h) { height_ = h; }
+
+    std::string const& get_name() const { return name_; }
+    void set_name(std::string const& n) { name_ = n; }
+};
+
+} // anonymous namespace
+
+void bench_property()
+{
+    v8pp::context context;
+    v8::Isolate* isolate = context.isolate();
+    v8::HandleScope scope(isolate);
+
+    using namespace v8pp::bench;
+    size_t const N = 10000;
+    size_t const S = 20;
+
+    v8pp::class_<Widget> widget_class(isolate);
+    widget_class
+        .ctor<>()
+        .property("width", &Widget::get_width, &Widget::set_width)
+        .property("height", &Widget::get_height, &Widget::set_height)
+        .property("name", &Widget::get_name, &Widget::set_name);
+    context.class_("Widget", widget_class);
+
+    context.run_script("var w = new Widget()");
+
+    // --- Property getter (int) ---
+    print_result(run_script_bench("property: get int (w.width)",
+        context, "w.width", N, S));
+
+    // --- Property setter (int) ---
+    print_result(run_script_bench("property: set int (w.width = 42)",
+        context, "w.width = 42", N, S));
+
+    // --- Property getter (string) ---
+    print_result(run_script_bench("property: get string (w.name)",
+        context, "w.name", N, S));
+
+    // --- Property setter (string) ---
+    print_result(run_script_bench("property: set string (w.name = 'x')",
+        context, "w.name = 'test'", N, S));
+
+    // --- Property read in tight loop ---
+    print_result(run_script_bench("property: 100x get in loop",
+        context, "var s = 0; for (var i = 0; i < 100; i++) s += w.width; s",
+        N / 10, S));
+
+    // --- Property write in tight loop ---
+    print_result(run_script_bench("property: 100x set in loop",
+        context, "for (var i = 0; i < 100; i++) w.width = i; w.width",
+        N / 10, S));
+}

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -1,0 +1,90 @@
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <v8.h>
+#include <libplatform/libplatform.h>
+
+#include "v8pp/version.hpp"
+
+void run_benchmarks()
+{
+    void bench_convert();
+    void bench_call();
+    void bench_class();
+    void bench_property();
+
+    std::pair<char const*, void (*)()> benchmarks[] =
+    {
+        { "bench_convert",  bench_convert },
+        { "bench_call",     bench_call },
+        { "bench_class",    bench_class },
+        { "bench_property", bench_property },
+    };
+
+    for (auto const& bench : benchmarks)
+    {
+        std::cout << "\n=== " << bench.first << " ===\n";
+        try
+        {
+            bench.second();
+        }
+        catch (std::exception const& ex)
+        {
+            std::cerr << "  error: " << ex.what() << '\n';
+        }
+    }
+}
+
+int main(int argc, char const* argv[])
+{
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string const arg = argv[i];
+        if (arg == "-h" || arg == "--help")
+        {
+            std::cout << "Usage: " << argv[0] << " [options]\n"
+                << "Options:\n"
+                << "  --help,-h      Print this message and exit\n"
+                << "  --version,-v   Print V8 and v8pp version\n"
+                ;
+            return 0;
+        }
+        else if (arg == "-v" || arg == "--version")
+        {
+            std::cout << "V8 version " << v8::V8::GetVersion() << "\n";
+            std::cout << "v8pp version " << v8pp::version() << "\n";
+            return 0;
+        }
+    }
+
+    v8::V8::SetFlagsFromString("--expose_gc");
+    v8::V8::InitializeExternalStartupData(argv[0]);
+
+#if V8_MAJOR_VERSION >= 7
+    std::unique_ptr<v8::Platform> platform(v8::platform::NewDefaultPlatform());
+#else
+    std::unique_ptr<v8::Platform> platform(v8::platform::CreateDefaultPlatform());
+#endif
+
+    v8::V8::InitializePlatform(platform.get());
+    v8::V8::Initialize();
+
+    std::cout << "V8 version " << v8::V8::GetVersion() << "\n";
+    std::cout << "v8pp version " << v8pp::version() << "\n";
+
+    run_benchmarks();
+
+    std::cout << "\ndone.\n";
+
+    v8::V8::Dispose();
+
+#if V8_MAJOR_VERSION > 9 || (V8_MAJOR_VERSION == 9 && V8_MINOR_VERSION >= 8)
+    v8::V8::DisposePlatform();
+#else
+    v8::V8::ShutdownPlatform();
+#endif
+
+    return 0;
+}

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -2,5 +2,8 @@ if(NOT TARGET v8pp::v8pp)
     # Provide path for scripts
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
+    include(CMakeFindDependencyMacro)
+    find_dependency(V8)
+
     include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
 endif()

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -3,9 +3,9 @@
 if(BUILD_SHARED_LIBS)
 	add_library(console MODULE console.cpp)
 	set_target_properties(console PROPERTIES PREFIX "")
-	target_link_libraries(console v8pp)
+	target_link_libraries(console PRIVATE v8pp)
 
 	add_library(file MODULE file.cpp)
 	set_target_properties(file PROPERTIES PREFIX "")
-	target_link_libraries(file v8pp)
+	target_link_libraries(file PRIVATE v8pp)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_executable(v8pp_test
 	main.cpp
 	test.hpp
+	test_adversarial.cpp
 	test_call_from_v8.cpp
 	test_call_v8.cpp
 	test_class.cpp
@@ -11,6 +12,7 @@ add_executable(v8pp_test
 	test_convert.cpp
 	test_fast_api.cpp
 	test_function.cpp
+	test_gc_stress.cpp
 	test_json.cpp
 	test_module.cpp
 	test_object.cpp
@@ -18,6 +20,7 @@ add_executable(v8pp_test
 	test_promise.cpp
 	test_property.cpp
 	test_symbol.cpp
+	test_thread_safety.cpp
 	test_ptr_traits.cpp
 	test_throw_ex.cpp
 	test_type_info.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(v8pp_test
 	test_call_v8.cpp
 	test_class.cpp
 	test_context.cpp
+	test_context_store.cpp
 	test_convert.cpp
 	test_fast_api.cpp
 	test_function.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,11 +35,11 @@ if(V8PP_HEADER_ONLY)
 	endif()
 endif()
 
-target_link_libraries(v8pp_test v8pp ${CMAKE_DL_LIBS})
+target_link_libraries(v8pp_test PRIVATE v8pp ${CMAKE_DL_LIBS})
 
-add_test(v8pp_test ${PROJECT_BINARY_DIR}/v8pp_test --version --run-tests)
+add_test(NAME v8pp_test COMMAND v8pp_test --version --run-tests)
 
 if(BUILD_SHARED_LIBS)
 	file(GLOB JS_TESTS *.js)
-	add_test(v8pp_js_test ${PROJECT_BINARY_DIR}/v8pp_test --lib-path ${PROJECT_BINARY_DIR}/plugins ${JS_TESTS})
+	add_test(NAME v8pp_js_test COMMAND v8pp_test --lib-path ${PROJECT_BINARY_DIR}/plugins ${JS_TESTS})
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,9 @@ add_executable(v8pp_test
 	test_module.cpp
 	test_object.cpp
 	test_overload.cpp
+	test_promise.cpp
 	test_property.cpp
+	test_symbol.cpp
 	test_ptr_traits.cpp
 	test_throw_ex.cpp
 	test_type_info.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,10 +8,12 @@ add_executable(v8pp_test
 	test_class.cpp
 	test_context.cpp
 	test_convert.cpp
+	test_fast_api.cpp
 	test_function.cpp
 	test_json.cpp
 	test_module.cpp
 	test_object.cpp
+	test_overload.cpp
 	test_property.cpp
 	test_ptr_traits.cpp
 	test_throw_ex.cpp

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -81,8 +81,6 @@ void run_tests()
 
 int main(int argc, char const* argv[])
 {
-	std::cerr << "[debug] main() entered" << std::endl;
-
 	std::vector<std::string> scripts;
 	std::string lib_path;
 	bool do_tests = false;
@@ -126,43 +124,29 @@ int main(int argc, char const* argv[])
 		}
 	}
 
-	std::cerr << "[debug] SetFlagsFromString" << std::endl;
 	// allow Isolate::RequestGarbageCollectionForTesting() before Initialize()
 	// for v8pp::class_ tests
 	v8::V8::SetFlagsFromString("--expose_gc");
 
-	std::cerr << "[debug] InitializeExternalStartupData" << std::endl;
 	//v8::V8::InitializeICU();
 	v8::V8::InitializeExternalStartupData(argv[0]);
-
-	std::cerr << "[debug] NewDefaultPlatform" << std::endl;
 #if V8_MAJOR_VERSION >= 7
 	std::unique_ptr<v8::Platform> platform(v8::platform::NewDefaultPlatform());
 #else
 	std::unique_ptr<v8::Platform> platform(v8::platform::CreateDefaultPlatform());
 #endif
-
-	std::cerr << "[debug] InitializePlatform" << std::endl;
 	v8::V8::InitializePlatform(platform.get());
-
-	std::cerr << "[debug] V8::Initialize" << std::endl;
 	v8::V8::Initialize();
-
-	std::cerr << "[debug] V8 initialized, do_tests=" << do_tests << " scripts=" << scripts.size() << std::endl;
 
 	if (do_tests || scripts.empty())
 	{
-		std::cerr << "[debug] running tests" << std::endl;
 		run_tests();
-		std::cerr << "[debug] tests finished" << std::endl;
 	}
 
 	int result = EXIT_SUCCESS;
 	try
 	{
-		std::cerr << "[debug] creating v8pp::context" << std::endl;
 		v8pp::context context;
-		std::cerr << "[debug] v8pp::context created" << std::endl;
 
 		if (!lib_path.empty())
 		{
@@ -173,25 +157,19 @@ int main(int argc, char const* argv[])
 			v8::HandleScope scope(context.isolate());
 			context.run_file(script);
 		}
-		std::cerr << "[debug] destroying v8pp::context" << std::endl;
 	}
 	catch (std::exception const& ex)
 	{
 		std::cerr << ex.what() << std::endl;
 		result = EXIT_FAILURE;
 	}
-	std::cerr << "[debug] v8pp::context destroyed" << std::endl;
 
-	std::cerr << "[debug] V8::Dispose" << std::endl;
 	v8::V8::Dispose();
-
-	std::cerr << "[debug] ShutdownPlatform" << std::endl;
 #if V8_MAJOR_VERSION > 9 || (V8_MAJOR_VERSION == 9 && V8_MINOR_VERSION >= 8)
 	v8::V8::DisposePlatform();
 #else
 	v8::V8::ShutdownPlatform();
 #endif
 
-	std::cerr << "[debug] clean exit" << std::endl;
 	return result;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -81,6 +81,8 @@ void run_tests()
 
 int main(int argc, char const* argv[])
 {
+	std::cerr << "[debug] main() entered" << std::endl;
+
 	std::vector<std::string> scripts;
 	std::string lib_path;
 	bool do_tests = false;
@@ -124,55 +126,72 @@ int main(int argc, char const* argv[])
 		}
 	}
 
+	std::cerr << "[debug] SetFlagsFromString" << std::endl;
 	// allow Isolate::RequestGarbageCollectionForTesting() before Initialize()
 	// for v8pp::class_ tests
 	v8::V8::SetFlagsFromString("--expose_gc");
 
+	std::cerr << "[debug] InitializeExternalStartupData" << std::endl;
 	//v8::V8::InitializeICU();
 	v8::V8::InitializeExternalStartupData(argv[0]);
+
+	std::cerr << "[debug] NewDefaultPlatform" << std::endl;
 #if V8_MAJOR_VERSION >= 7
 	std::unique_ptr<v8::Platform> platform(v8::platform::NewDefaultPlatform());
 #else
 	std::unique_ptr<v8::Platform> platform(v8::platform::CreateDefaultPlatform());
 #endif
+
+	std::cerr << "[debug] InitializePlatform" << std::endl;
 	v8::V8::InitializePlatform(platform.get());
+
+	std::cerr << "[debug] V8::Initialize" << std::endl;
 	v8::V8::Initialize();
+
+	std::cerr << "[debug] V8 initialized, do_tests=" << do_tests << " scripts=" << scripts.size() << std::endl;
 
 	if (do_tests || scripts.empty())
 	{
+		std::cerr << "[debug] running tests" << std::endl;
 		run_tests();
+		std::cerr << "[debug] tests finished" << std::endl;
 	}
 
 	int result = EXIT_SUCCESS;
-	if (!scripts.empty())
+	try
 	{
-		try
-		{
-			v8pp::context context;
+		std::cerr << "[debug] creating v8pp::context" << std::endl;
+		v8pp::context context;
+		std::cerr << "[debug] v8pp::context created" << std::endl;
 
-			if (!lib_path.empty())
-			{
-				context.set_lib_path(lib_path);
-			}
-			for (std::string const& script : scripts)
-			{
-				v8::HandleScope scope(context.isolate());
-				context.run_file(script);
-			}
-		}
-		catch (std::exception const& ex)
+		if (!lib_path.empty())
 		{
-			std::cerr << ex.what() << std::endl;
-			result = EXIT_FAILURE;
+			context.set_lib_path(lib_path);
 		}
+		for (std::string const& script : scripts)
+		{
+			v8::HandleScope scope(context.isolate());
+			context.run_file(script);
+		}
+		std::cerr << "[debug] destroying v8pp::context" << std::endl;
 	}
+	catch (std::exception const& ex)
+	{
+		std::cerr << ex.what() << std::endl;
+		result = EXIT_FAILURE;
+	}
+	std::cerr << "[debug] v8pp::context destroyed" << std::endl;
 
+	std::cerr << "[debug] V8::Dispose" << std::endl;
 	v8::V8::Dispose();
+
+	std::cerr << "[debug] ShutdownPlatform" << std::endl;
 #if V8_MAJOR_VERSION > 9 || (V8_MAJOR_VERSION == 9 && V8_MINOR_VERSION >= 8)
 	v8::V8::DisposePlatform();
 #else
 	v8::V8::ShutdownPlatform();
 #endif
 
+	std::cerr << "[debug] clean exit" << std::endl;
 	return result;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -27,6 +27,8 @@ void run_tests()
 	void test_property();
 	void test_object();
 	void test_json();
+	void test_overload();
+	void test_fast_api();
 
 	std::pair<char const*, void (*)()> tests[] =
 	{
@@ -44,6 +46,8 @@ void run_tests()
 		{"test_property", test_property},
 		{"test_object", test_object},
 		{"test_json", test_json},
+		{"test_overload", test_overload},
+		{"test_fast_api", test_fast_api},
 	};
 
 	for (auto const& test : tests)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -29,6 +29,8 @@ void run_tests()
 	void test_json();
 	void test_overload();
 	void test_fast_api();
+	void test_symbol();
+	void test_promise();
 
 	std::pair<char const*, void (*)()> tests[] =
 	{
@@ -48,6 +50,8 @@ void run_tests()
 		{"test_json", test_json},
 		{"test_overload", test_overload},
 		{"test_fast_api", test_fast_api},
+		{"test_symbol", test_symbol},
+		{"test_promise", test_promise},
 	};
 
 	for (auto const& test : tests)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -32,6 +32,9 @@ void run_tests()
 	void test_fast_api();
 	void test_symbol();
 	void test_promise();
+	void test_gc_stress();
+	void test_adversarial();
+	void test_thread_safety();
 
 	std::pair<char const*, void (*)()> tests[] =
 	{
@@ -54,6 +57,9 @@ void run_tests()
 		{"test_fast_api", test_fast_api},
 		{"test_symbol", test_symbol},
 		{"test_promise", test_promise},
+		{"test_gc_stress", test_gc_stress},
+		{"test_adversarial", test_adversarial},
+		{"test_thread_safety", test_thread_safety},
 	};
 
 	for (auto const& test : tests)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -144,24 +144,27 @@ int main(int argc, char const* argv[])
 	}
 
 	int result = EXIT_SUCCESS;
-	try
+	if (!scripts.empty())
 	{
-		v8pp::context context;
+		try
+		{
+			v8pp::context context;
 
-		if (!lib_path.empty())
-		{
-			context.set_lib_path(lib_path);
+			if (!lib_path.empty())
+			{
+				context.set_lib_path(lib_path);
+			}
+			for (std::string const& script : scripts)
+			{
+				v8::HandleScope scope(context.isolate());
+				context.run_file(script);
+			}
 		}
-		for (std::string const& script : scripts)
+		catch (std::exception const& ex)
 		{
-			v8::HandleScope scope(context.isolate());
-			context.run_file(script);
+			std::cerr << ex.what() << std::endl;
+			result = EXIT_FAILURE;
 		}
-	}
-	catch (std::exception const& ex)
-	{
-		std::cerr << ex.what() << std::endl;
-		result = EXIT_FAILURE;
 	}
 
 	v8::V8::Dispose();

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -16,6 +16,7 @@ void run_tests()
 	void test_type_info();
 	void test_utility();
 	void test_context();
+	void test_context_store();
 	void test_convert();
 	void test_throw_ex();
 	void test_call_v8();
@@ -37,6 +38,7 @@ void run_tests()
 		{ "test_type_info", test_type_info },
 		{"test_utility", test_utility},
 		{"test_context", test_context},
+		{"test_context_store", test_context_store},
 		{"test_convert", test_convert},
 		{"test_throw_ex", test_throw_ex},
 		{"test_function", test_function},

--- a/test/test_adversarial.cpp
+++ b/test/test_adversarial.cpp
@@ -1,0 +1,320 @@
+#include "v8pp/class.hpp"
+#include "v8pp/context.hpp"
+#include "v8pp/convert.hpp"
+
+#include "test.hpp"
+
+#include <atomic>
+#include <string>
+
+namespace {
+
+struct Adv
+{
+	int value;
+
+	explicit Adv(int v = 0) : value(v) {}
+	int get() const { return value; }
+	void set(int v) { value = v; }
+	int add(int x) const { return value + x; }
+};
+
+struct Adv2
+{
+	std::string name;
+	explicit Adv2(std::string n = "") : name(std::move(n)) {}
+	std::string get_name() const { return name; }
+};
+
+struct ThrowingObj
+{
+	static std::atomic<int> instance_count;
+	int value;
+
+	explicit ThrowingObj(int v)
+	{
+		if (v < 0) throw std::runtime_error("negative value");
+		value = v;
+		++instance_count;
+	}
+	~ThrowingObj() { --instance_count; }
+
+	int get() const { return value; }
+
+	int throwing_method() const
+	{
+		throw std::runtime_error("method error");
+	}
+
+	int throwing_getter() const
+	{
+		throw std::runtime_error("getter error");
+	}
+
+	void throwing_setter(int)
+	{
+		throw std::runtime_error("setter error");
+	}
+};
+
+std::atomic<int> ThrowingObj::instance_count = 0;
+
+//
+// Adversarial JS tests
+//
+
+template<typename Traits>
+void test_adversarial_js()
+{
+	v8pp::context context;
+	v8::Isolate* isolate = context.isolate();
+	v8::HandleScope scope(isolate);
+
+	v8pp::class_<Adv, Traits> adv_class(isolate);
+	adv_class
+		.template ctor<int>()
+		.var("value", &Adv::value)
+		.property("prop", &Adv::get, &Adv::set)
+		.function("add", &Adv::add)
+		.function("get", &Adv::get);
+
+	v8pp::class_<Adv2, Traits> adv2_class(isolate);
+	adv2_class
+		.template ctor<std::string>()
+		.function("get_name", &Adv2::get_name);
+
+	context
+		.class_("Adv", adv_class)
+		.class_("Adv2", adv2_class);
+
+	// Proxy forwarding: method call through proxy uses proxy as `this`,
+	// which has no internal fields, so unwrap_object correctly rejects it.
+	// The key assertion is no crash.
+	check_eq("proxy forwarding",
+		run_script<std::string>(context,
+			"var x = new Adv(5);"
+			"var p = new Proxy(x, {"
+			"  get: function(t, prop) { return t[prop]; },"
+			"  set: function(t, prop, val) { t[prop] = val; return true; }"
+			"});"
+			"try { String(p.add(10)); } catch(e) { 'caught'; }"),
+		"caught");
+
+	// Proxy with throwing get trap
+	check_eq("proxy throwing trap",
+		run_script<std::string>(context,
+			"var x = new Adv(5);"
+			"var p = new Proxy(x, {"
+			"  get: function(t, prop) { throw new Error('trap!'); }"
+			"});"
+			"try { p.add(1); 'no error'; } catch(e) { 'caught'; }"),
+		"caught");
+
+	// defineProperty on wrapped instance — may throw TypeError (non-configurable)
+	// or succeed depending on V8 version and property type. Must not crash.
+	{
+		auto result = run_script<std::string>(context,
+			"var x = new Adv(5);"
+			"try {"
+			"  Object.defineProperty(x, 'value', { get: function() { return 999; } });"
+			"  'redefined';"
+			"} catch(e) { 'caught'; }");
+		check("defineProperty on wrapped instance (no crash)",
+			result == "caught" || result == "redefined");
+	}
+
+	// Frozen object — read should still work
+	check_eq("frozen object read",
+		run_script<int>(context,
+			"var x = new Adv(42);"
+			"Object.freeze(x);"
+			"x.get()"),
+		42);
+
+	// Frozen object — mutation attempt. Native interceptors may bypass freeze.
+	// Must not crash regardless of outcome.
+	{
+		auto result = run_script<std::string>(context,
+			"'use strict';"
+			"var x = new Adv(42);"
+			"Object.freeze(x);"
+			"try { x.value = 10; 'no error'; } catch(e) { 'caught'; }");
+		check("frozen object mutate (no crash)",
+			result == "caught" || result == "no error");
+	}
+
+	// Null prototype — method call should fail (method no longer on chain)
+	check_eq("null prototype method call",
+		run_script<std::string>(context,
+			"var x = new Adv(5);"
+			"Object.setPrototypeOf(x, null);"
+			"try { x.add(1); 'no error'; } catch(e) { 'caught'; }"),
+		"caught");
+
+	// Constructor called as function without `new` — should throw, not crash
+	check_eq("constructor without new",
+		run_script<std::string>(context,
+			"try { Adv(1); 'no error'; } catch(e) { 'caught'; }"),
+		"caught");
+
+	// Circular prototype attempt — V8 prevents this
+	check_eq("circular prototype",
+		run_script<std::string>(context,
+			"var a = {}; var b = {};"
+			"Object.setPrototypeOf(a, b);"
+			"try { Object.setPrototypeOf(b, a); 'no error'; } catch(e) { 'caught'; }"),
+		"caught");
+
+	// GetOwnPropertyDescriptor on native property — should not crash.
+	// Property may be on prototype (not own), so descriptor can be undefined.
+	{
+		auto result = run_script<std::string>(context,
+			"var x = new Adv(7);"
+			"var desc = Object.getOwnPropertyDescriptor(x, 'value');"
+			"desc !== undefined ? 'own' : 'proto'");
+		check("getOwnPropertyDescriptor (no crash)",
+			result == "own" || result == "proto");
+	}
+
+	// Spread wrapped object — must not crash
+	{
+		auto result = run_script<std::string>(context,
+			"var x = new Adv(3);"
+			"try { var copy = {...x}; 'ok'; } catch(e) { 'caught'; }");
+		check("spread wrapped object (no crash)",
+			result == "ok" || result == "caught");
+	}
+
+	// Prototype swap between different wrapped types
+	check_eq("prototype swap between types",
+		run_script<std::string>(context,
+			"var a = new Adv(1);"
+			"var b = new Adv2('hello');"
+			"try {"
+			"  Object.setPrototypeOf(a, Object.getPrototypeOf(b));"
+			"  a.get_name();"
+			"  'no error';"
+			"} catch(e) { 'caught'; }"),
+		"caught");
+
+	// Method extracted and called on wrong receiver
+	check_eq("method on wrong receiver",
+		run_script<std::string>(context,
+			"var x = new Adv(5);"
+			"var f = x.add;"
+			"try { f.call({}, 1); 'no error'; } catch(e) { 'caught'; }"),
+		"caught");
+
+	// Method called on plain object via .call()
+	check_eq("method via call on plain obj",
+		run_script<std::string>(context,
+			"try { var x = new Adv(5); x.add.call({value: 99}, 1); 'no error'; } catch(e) { 'caught'; }"),
+		"caught");
+
+	// Property getter extracted and called on wrong receiver
+	check_eq("property getter on wrong receiver",
+		run_script<std::string>(context,
+			"var desc = Object.getOwnPropertyDescriptor(new Adv(5), 'prop');"
+			"try { desc.get.call({}); 'no error'; } catch(e) { 'caught'; }"),
+		"caught");
+
+	// Property setter extracted and called on wrong receiver
+	check_eq("property setter on wrong receiver",
+		run_script<std::string>(context,
+			"var desc = Object.getOwnPropertyDescriptor(new Adv(5), 'prop');"
+			"try { desc.set.call({}, 42); 'no error'; } catch(e) { 'caught'; }"),
+		"caught");
+
+	// Deep prototype chain (beyond 16 limit)
+	check_eq("deep prototype chain",
+		run_script<std::string>(context,
+			"var obj = {};"
+			"for (var i = 0; i < 20; i++) { obj = Object.create(obj); }"
+			"try { var x = new Adv(1); x.add.call(obj, 1); 'no error'; } catch(e) { 'caught'; }"),
+		"caught");
+}
+
+//
+// Exception safety tests
+//
+
+template<typename Traits>
+void test_exception_safety()
+{
+	ThrowingObj::instance_count = 0;
+
+	v8pp::context context;
+	v8::Isolate* isolate = context.isolate();
+	v8::HandleScope scope(isolate);
+
+	v8pp::class_<ThrowingObj, Traits> throwing_class(isolate);
+	throwing_class
+		.template ctor<int>()
+		.function("get", &ThrowingObj::get)
+		.function("throwing_method", &ThrowingObj::throwing_method)
+		.property("throwing_prop", &ThrowingObj::throwing_getter, &ThrowingObj::throwing_setter);
+
+	context.class_("ThrowingObj", throwing_class);
+
+	// Constructor that throws — should produce JS exception, not crash
+	check_eq("throwing ctor produces JS exception",
+		run_script<std::string>(context,
+			"try { new ThrowingObj(-1); 'no error'; } catch(e) { e.message; }"),
+		"negative value");
+
+	// No instances should have been created
+	check_eq("throwing ctor no leak", ThrowingObj::instance_count.load(), 0);
+
+	// Successful construction
+	check_eq("successful ctor", run_script<int>(context, "var t = new ThrowingObj(5); t.get()"), 5);
+	check_eq("instance created", ThrowingObj::instance_count.load(), 1);
+
+	// Method that throws — should produce JS exception, object still valid
+	check_eq("throwing method",
+		run_script<std::string>(context,
+			"try { t.throwing_method(); 'no error'; } catch(e) { e.message; }"),
+		"method error");
+
+	// Object should still be usable after method exception
+	check_eq("object valid after method throw", run_script<int>(context, "t.get()"), 5);
+
+	// Property getter that throws — v8pp's property_get catch block only
+	// re-throws to JS when ShouldThrowOnError() (strict mode). In sloppy mode
+	// the C++ exception is silently swallowed and the property reads as undefined.
+	{
+		auto result = run_script<std::string>(context,
+			"try { t.throwing_prop; 'no error'; } catch(e) { e.message; }");
+		check("throwing property getter (no crash)",
+			result == "getter error" || result == "no error");
+	}
+
+	// Property setter that throws — same ShouldThrowOnError behavior
+	{
+		auto result = run_script<std::string>(context,
+			"try { t.throwing_prop = 42; 'no error'; } catch(e) { e.message; }");
+		check("throwing property setter (no crash)",
+			result == "setter error" || result == "no error");
+	}
+
+	// Object still valid after property exceptions
+	check_eq("object valid after prop throw", run_script<int>(context, "t.get()"), 5);
+
+	// Destroy objects, then try to use from JS
+	v8pp::class_<ThrowingObj, Traits>::destroy_objects(isolate);
+
+	check_eq("use after destroy_objects",
+		run_script<std::string>(context,
+			"try { t.get(); 'no error'; } catch(e) { 'caught'; }"),
+		"caught");
+}
+
+} // anonymous namespace
+
+void test_adversarial()
+{
+	test_adversarial_js<v8pp::raw_ptr_traits>();
+	test_adversarial_js<v8pp::shared_ptr_traits>();
+
+	test_exception_safety<v8pp::raw_ptr_traits>();
+	test_exception_safety<v8pp::shared_ptr_traits>();
+}

--- a/test/test_context_store.cpp
+++ b/test/test_context_store.cpp
@@ -1,0 +1,319 @@
+#include "v8pp/context_store.hpp"
+#include "v8pp/json.hpp"
+
+#include "test.hpp"
+
+#include <algorithm>
+#include <type_traits>
+
+static_assert(std::is_move_constructible_v<v8pp::context_store>);
+static_assert(std::is_move_assignable_v<v8pp::context_store>);
+static_assert(!std::is_copy_assignable_v<v8pp::context_store>);
+static_assert(!std::is_copy_constructible_v<v8pp::context_store>);
+
+void test_context_store()
+{
+	// Test 1: basic set/get with V8 value
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::context_store store(isolate);
+		check("store isolate", store.isolate() == isolate);
+		check("store impl", !store.impl().IsEmpty());
+
+		store.set("answer", v8pp::to_v8(isolate, 42));
+
+		v8::Local<v8::Value> out;
+		check("get existing", store.get("answer", out));
+		check_eq("get value", v8pp::from_v8<int>(isolate, out), 42);
+
+		check("get nonexistent", !store.get("missing", out));
+	}
+
+	// Test 2: typed set/get
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::context_store store(isolate);
+		store.set<int>("num", 42);
+		store.set<std::string>("str", "hello");
+		store.set<double>("pi", 3.14);
+		store.set<bool>("flag", true);
+
+		int num = 0;
+		check("get int", store.get("num", num));
+		check_eq("int value", num, 42);
+
+		std::string str;
+		check("get string", store.get("str", str));
+		check_eq("string value", str, "hello");
+
+		double pi = 0;
+		check("get double", store.get("pi", pi));
+		check_eq("double value", pi, 3.14);
+
+		bool flag = false;
+		check("get bool", store.get("flag", flag));
+		check_eq("bool value", flag, true);
+	}
+
+	// Test 3: has / remove
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::context_store store(isolate);
+		check("has before set", !store.has("key"));
+
+		store.set<int>("key", 1);
+		check("has after set", store.has("key"));
+
+		check("remove existing", store.remove("key"));
+		check("has after remove", !store.has("key"));
+		check("remove nonexistent", !store.remove("key"));
+	}
+
+	// Test 4: clear / size / keys
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::context_store store(isolate);
+		check_eq("empty size", store.size(), size_t(0));
+		check_eq("empty keys", store.keys().size(), size_t(0));
+
+		store.set<int>("a", 1);
+		store.set<int>("b", 2);
+		store.set<int>("c", 3);
+		check_eq("size after set", store.size(), size_t(3));
+
+		auto k = store.keys();
+		check_eq("keys count", k.size(), size_t(3));
+		std::sort(k.begin(), k.end());
+		check_eq("key 0", k[0], "a");
+		check_eq("key 1", k[1], "b");
+		check_eq("key 2", k[2], "c");
+
+		store.clear();
+		check_eq("size after clear", store.size(), size_t(0));
+		check("has after clear", !store.has("a"));
+	}
+
+	// Test 5: overwrite
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::context_store store(isolate);
+		store.set<int>("key", 1);
+		store.set<int>("key", 2);
+
+		int val = 0;
+		check("get overwritten", store.get("key", val));
+		check_eq("overwritten value", val, 2);
+		check_eq("size after overwrite", store.size(), size_t(1));
+	}
+
+	// Test 6: dot-separated names
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::context_store store(isolate);
+		store.set<int>("a.b.c", 42);
+
+		check("has a.b.c", store.has("a.b.c"));
+		check("has a.b", store.has("a.b"));
+		check("has a", store.has("a"));
+
+		int val = 0;
+		check("get a.b.c", store.get("a.b.c", val));
+		check_eq("nested value", val, 42);
+	}
+
+	// Test 7: cross-context lifecycle (the critical test)
+	{
+		v8::Isolate* isolate = v8pp::context::create_isolate();
+		{
+			v8::Isolate::Scope isolate_scope(isolate);
+			v8::HandleScope outer_scope(isolate);
+
+			v8pp::context_store store(isolate);
+
+			// Phase 1: create context, set values, save to store
+			{
+				v8pp::context ctx(isolate, nullptr, false, false);
+				v8::HandleScope scope(isolate);
+				v8::Context::Scope context_scope(ctx.impl());
+
+				ctx.run_script("var state = 42; var config = 'hello';");
+				store.save_from(ctx.impl(), {"state", "config"});
+			}
+			// ctx destroyed here
+
+			// Phase 2: create new context, restore from store
+			{
+				v8pp::context ctx(isolate, nullptr, false, false);
+				v8::HandleScope scope(isolate);
+				v8::Context::Scope context_scope(ctx.impl());
+
+				store.restore_to(ctx.impl(), {"state", "config"});
+
+				auto state = ctx.run_script("state")->Int32Value(
+					isolate->GetCurrentContext()).FromJust();
+				check_eq("restored state", state, 42);
+
+				auto config = v8pp::from_v8<std::string>(isolate, ctx.run_script("config"));
+				check_eq("restored config", config, "hello");
+			}
+		}
+		isolate->Dispose();
+	}
+
+	// Test 8: JS object survives context switch
+	{
+		v8::Isolate* isolate = v8pp::context::create_isolate();
+		{
+			v8::Isolate::Scope isolate_scope(isolate);
+			v8::HandleScope outer_scope(isolate);
+
+			v8pp::context_store store(isolate);
+
+			// Save an object from ctx1
+			{
+				v8pp::context ctx(isolate, nullptr, false, false);
+				v8::HandleScope scope(isolate);
+				v8::Context::Scope context_scope(ctx.impl());
+
+				v8::Local<v8::Value> obj = ctx.run_script("({x: 10, y: 20})");
+				store.set("obj", obj);
+			}
+
+			// Retrieve in ctx2
+			{
+				v8pp::context ctx(isolate, nullptr, false, false);
+				v8::HandleScope scope(isolate);
+				v8::Context::Scope context_scope(ctx.impl());
+
+				v8::Local<v8::Value> obj;
+				check("get obj", store.get("obj", obj));
+				check("obj is object", obj->IsObject());
+
+				// Set it in the new context and verify properties
+				ctx.impl()->Global()->Set(isolate->GetCurrentContext(),
+					v8pp::to_v8(isolate, "obj"), obj).FromJust();
+				auto x = ctx.run_script("obj.x")->Int32Value(
+					isolate->GetCurrentContext()).FromJust();
+				check_eq("obj.x", x, 10);
+
+				auto y = ctx.run_script("obj.y")->Int32Value(
+					isolate->GetCurrentContext()).FromJust();
+				check_eq("obj.y", y, 20);
+			}
+		}
+		isolate->Dispose();
+	}
+
+	// Test 9: bulk save_from / restore_to
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::context_store store(isolate);
+		store.set<int>("a", 1);
+		store.set<int>("b", 2);
+		store.set<int>("c", 3);
+
+		// save_from with nonexistent key
+		auto saved = store.save_from(context.impl(), {"missing"});
+		check_eq("save nonexistent", saved, size_t(0));
+
+		// restore partial
+		auto restored = store.restore_to(context.impl(), {"a", "b"});
+		check_eq("restore count", restored, size_t(2));
+
+		auto a = run_script<int>(context, "a");
+		check_eq("restored a", a, 1);
+		auto b = run_script<int>(context, "b");
+		check_eq("restored b", b, 2);
+	}
+
+	// Test 10: JSON deep copy
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		// Create an object and store a JSON deep copy
+		v8pp::context_store store(isolate);
+		v8::Local<v8::Value> obj = context.run_script("({val: 100})");
+		check("set_json", store.set_json("data", obj));
+
+		// Modify the original
+		context.run_script("// original is separate, store has its own copy");
+
+		// Retrieve the deep copy
+		v8::Local<v8::Value> copy;
+		check("get_json", store.get_json("data", copy));
+		check("copy is object", copy->IsObject());
+
+		// Verify the copy has the original value
+		context.impl()->Global()->Set(isolate->GetCurrentContext(),
+			v8pp::to_v8(isolate, "copy"), copy).FromJust();
+		check_eq("json copy value", run_script<int>(context, "copy.val"), 100);
+	}
+
+	// Test 11: move semantics
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::context_store store1(isolate);
+		store1.set<int>("key", 42);
+
+		v8pp::context_store store2(std::move(store1));
+		check("moved-from isolate", store1.isolate() == nullptr);
+		check("moved-to isolate", store2.isolate() == isolate);
+		check("moved-to impl", !store2.impl().IsEmpty());
+
+		int val = 0;
+		check("get from moved-to", store2.get("key", val));
+		check_eq("moved value", val, 42);
+	}
+
+	// Test 12: store outlives multiple contexts
+	{
+		v8::Isolate* isolate = v8pp::context::create_isolate();
+		{
+			v8::Isolate::Scope isolate_scope(isolate);
+			v8::HandleScope outer_scope(isolate);
+
+			v8pp::context_store store(isolate);
+			store.set<int>("persistent", 99);
+
+			// Create and destroy 3 contexts
+			for (int i = 0; i < 3; ++i)
+			{
+				v8pp::context ctx(isolate, nullptr, false, false);
+				v8::HandleScope scope(isolate);
+				v8::Context::Scope context_scope(ctx.impl());
+
+				// Verify store still works
+				int val = 0;
+				check("get persistent", store.get("persistent", val));
+				check_eq("persistent value", val, 99);
+			}
+		}
+		isolate->Dispose();
+	}
+}

--- a/test/test_fast_api.cpp
+++ b/test/test_fast_api.cpp
@@ -1,0 +1,105 @@
+#include "v8pp/class.hpp"
+#include "v8pp/context.hpp"
+#include "v8pp/fast_api.hpp"
+#include "v8pp/module.hpp"
+
+#include "test.hpp"
+
+// Free functions for fast API testing
+static int32_t fast_add(int32_t a, int32_t b) { return a + b; }
+static double fast_mul(double a, double b) { return a * b; }
+static bool fast_negate(bool x) { return !x; }
+static uint32_t fast_square(uint32_t x) { return x * x; }
+
+// Non-compatible functions (should silently fall back to slow-only)
+static std::string slow_greet(std::string name) { return "hello " + name; }
+static int isolate_func(v8::Isolate*, int x) { return x; }
+
+// Compile-time compatibility checks
+static_assert(v8pp::detail::is_fast_api_compatible<decltype(&fast_add)>::value);
+static_assert(v8pp::detail::is_fast_api_compatible<decltype(&fast_mul)>::value);
+static_assert(v8pp::detail::is_fast_api_compatible<decltype(&fast_negate)>::value);
+static_assert(v8pp::detail::is_fast_api_compatible<decltype(&fast_square)>::value);
+static_assert(!v8pp::detail::is_fast_api_compatible<decltype(&slow_greet)>::value);
+static_assert(!v8pp::detail::is_fast_api_compatible<decltype(&isolate_func)>::value);
+
+// Return type checks
+static_assert(v8pp::detail::is_fast_return_type_v<void>);
+static_assert(v8pp::detail::is_fast_return_type_v<bool>);
+static_assert(v8pp::detail::is_fast_return_type_v<int32_t>);
+static_assert(v8pp::detail::is_fast_return_type_v<float>);
+static_assert(v8pp::detail::is_fast_return_type_v<double>);
+static_assert(!v8pp::detail::is_fast_return_type_v<int64_t>);
+static_assert(!v8pp::detail::is_fast_return_type_v<std::string>);
+
+// Arg type checks
+static_assert(v8pp::detail::is_fast_arg_type_v<int32_t>);
+static_assert(v8pp::detail::is_fast_arg_type_v<int64_t>);
+static_assert(v8pp::detail::is_fast_arg_type_v<uint64_t>);
+static_assert(!v8pp::detail::is_fast_arg_type_v<std::string>);
+static_assert(!v8pp::detail::is_fast_arg_type_v<v8::Isolate*>);
+
+void test_fast_api()
+{
+	v8pp::context context;
+	v8::Isolate* isolate = context.isolate();
+	v8::HandleScope scope(isolate);
+
+	// --- Free function: int32_t + int32_t ---
+	context.function("fast_add", v8pp::fast_fn<&fast_add>);
+	check_eq("fast_api: add ints", run_script<int>(context, "fast_add(10, 20)"), 30);
+	check_eq("fast_api: add negative", run_script<int>(context, "fast_add(-5, 3)"), -2);
+
+	// --- Free function: double * double ---
+	context.function("fast_mul", v8pp::fast_fn<&fast_mul>);
+	check_eq("fast_api: mul doubles", run_script<double>(context, "fast_mul(1.5, 3.0)"), 4.5);
+
+	// --- Bool return ---
+	context.function("fast_negate", v8pp::fast_fn<&fast_negate>);
+	check_eq("fast_api: negate true", run_script<bool>(context, "fast_negate(true)"), false);
+	check_eq("fast_api: negate false", run_script<bool>(context, "fast_negate(false)"), true);
+
+	// --- uint32_t ---
+	context.function("fast_square", v8pp::fast_fn<&fast_square>);
+	check_eq("fast_api: square", run_script<int>(context, "fast_square(7)"), 49);
+
+	// --- Non-compatible function silently falls back to slow ---
+	context.function("slow_greet", v8pp::fast_fn<&slow_greet>);
+	check_eq("fast_api: slow fallback", run_script<std::string>(context, "slow_greet('world')"), "hello world");
+
+	// --- Module function with fast API ---
+	{
+		v8pp::module m(isolate);
+		m.function("compute", v8pp::fast_fn<&fast_add>);
+		context.module("fast_mod", m);
+
+		check_eq("fast_api: module func", run_script<int>(context, "fast_mod.compute(3, 4)"), 7);
+	}
+
+	// --- Class member function with fast API ---
+	{
+		struct Vec
+		{
+			int32_t x = 0;
+			int32_t y = 0;
+			int32_t sum() const { return x + y; }
+			int32_t dot(int32_t ox, int32_t oy) const { return x * ox + y * oy; }
+		};
+
+		v8pp::class_<Vec> vec_class(isolate);
+		vec_class
+			.ctor<>()
+			.var("x", &Vec::x)
+			.var("y", &Vec::y)
+			.function("sum", v8pp::fast_fn<&Vec::sum>)
+			.function("dot", v8pp::fast_fn<&Vec::dot>);
+		context.class_("Vec", vec_class);
+
+		check_eq("fast_api: member sum", run_script<int>(context, "var v = new Vec(); v.x = 3; v.y = 4; v.sum()"), 7);
+		check_eq("fast_api: member dot", run_script<int>(context, "v.dot(2, 3)"), 18);
+	}
+
+	// --- Lambda as fast_fn is not supported (lambdas can't be NTTPs) ---
+	// This is by design: fast_fn requires a function pointer known at compile time.
+	// Use regular .function() for lambdas.
+}

--- a/test/test_gc_stress.cpp
+++ b/test/test_gc_stress.cpp
@@ -186,7 +186,7 @@ void test_gc_stress_inheritance()
 	v8pp::class_<GCDerived, Traits> derived_class(isolate);
 	derived_class
 		.template ctor<int>()
-		.inherit<GCBase>()
+		.template inherit<GCBase>()
 		.function("get_y", &GCDerived::get_y);
 
 	context.class_("GCBase", base_class);

--- a/test/test_gc_stress.cpp
+++ b/test/test_gc_stress.cpp
@@ -1,0 +1,224 @@
+#include "v8pp/class.hpp"
+#include "v8pp/context.hpp"
+
+#include "test.hpp"
+
+#include <atomic>
+#include <string>
+
+namespace {
+
+struct GCObj
+{
+	static std::atomic<int> instance_count;
+	int value;
+
+	explicit GCObj(int v = 0) : value(v) { ++instance_count; }
+	~GCObj() { --instance_count; }
+
+	int get() const { return value; }
+};
+
+std::atomic<int> GCObj::instance_count = 0;
+
+struct GCBase
+{
+	static std::atomic<int> base_count;
+	int x;
+
+	explicit GCBase(int v = 0) : x(v) { ++base_count; }
+	~GCBase() { --base_count; }
+
+	int get_x() const { return x; }
+};
+
+std::atomic<int> GCBase::base_count = 0;
+
+struct GCDerived : GCBase
+{
+	static std::atomic<int> derived_count;
+	int y;
+
+	explicit GCDerived(int v = 0) : GCBase(v), y(v * 2) { ++derived_count; }
+	~GCDerived() { --derived_count; }
+
+	int get_y() const { return y; }
+};
+
+std::atomic<int> GCDerived::derived_count = 0;
+
+void force_gc(v8::Isolate* isolate)
+{
+	// Force GC twice to ensure weak callbacks are processed
+	isolate->RequestGarbageCollectionForTesting(
+		v8::Isolate::GarbageCollectionType::kFullGarbageCollection);
+	isolate->RequestGarbageCollectionForTesting(
+		v8::Isolate::GarbageCollectionType::kFullGarbageCollection);
+}
+
+template<typename Traits>
+void test_gc_stress_bulk()
+{
+	GCObj::instance_count = 0;
+
+	v8pp::context context;
+	v8::Isolate* isolate = context.isolate();
+	v8::HandleScope scope(isolate);
+
+	v8pp::class_<GCObj, Traits> GCObj_class(isolate);
+	GCObj_class
+		.template ctor<int>()
+		.function("get", &GCObj::get);
+
+	context.class_("GCObj", GCObj_class);
+
+	// Create 10k objects in batches via JS, all unreferenced immediately
+	for (int batch = 0; batch < 100; ++batch)
+	{
+		v8::HandleScope batch_scope(isolate);
+		run_script<int>(context,
+			"for (var i = 0; i < 100; i++) { new GCObj(i); } 0");
+	}
+
+	// Force GC to reclaim all unreferenced objects
+	force_gc(isolate);
+
+	check_eq("bulk 10k GC cleanup", GCObj::instance_count.load(), 0);
+}
+
+template<typename Traits>
+void test_gc_stress_mixed_lifespan()
+{
+	GCObj::instance_count = 0;
+
+	v8pp::context context;
+	v8::Isolate* isolate = context.isolate();
+	v8::HandleScope scope(isolate);
+
+	v8pp::class_<GCObj, Traits> GCObj_class(isolate);
+	GCObj_class
+		.template ctor<int>()
+		.function("get", &GCObj::get);
+
+	context.class_("GCObj", GCObj_class);
+
+	// Hold 100 objects alive via reference_external
+	std::vector<typename Traits::template object_pointer_type<GCObj>> held;
+	for (int i = 0; i < 100; ++i)
+	{
+		auto obj = Traits::template create<GCObj>(i);
+		v8pp::class_<GCObj, Traits>::reference_external(isolate, obj);
+		held.push_back(obj);
+	}
+
+	// Create 10k more objects via JS (all unreferenced)
+	for (int batch = 0; batch < 100; ++batch)
+	{
+		v8::HandleScope batch_scope(isolate);
+		run_script<int>(context,
+			"for (var i = 0; i < 100; i++) { new GCObj(i); } 0");
+	}
+
+	force_gc(isolate);
+
+	// The 100 held objects should survive GC
+	check_eq("mixed lifespan after GC", GCObj::instance_count.load(), 100);
+
+	// Unreference all held objects
+	for (auto& obj : held)
+	{
+		v8pp::class_<GCObj, Traits>::unreference_external(isolate, obj);
+	}
+	held.clear();
+
+	force_gc(isolate);
+
+	bool constexpr use_shared_ptr = std::same_as<Traits, v8pp::shared_ptr_traits>;
+	// raw_ptr: unreference doesn't delete, so objects still exist until scope ends
+	// shared_ptr: unreference removes registry entry, shared_ptr copies in held are cleared
+	check_eq("mixed lifespan fully cleaned",
+		GCObj::instance_count.load(), use_shared_ptr ? 0 : 100);
+}
+
+template<typename Traits>
+void test_gc_stress_rapid_cycles()
+{
+	GCObj::instance_count = 0;
+
+	v8pp::context context;
+	v8::Isolate* isolate = context.isolate();
+	v8::HandleScope scope(isolate);
+
+	v8pp::class_<GCObj, Traits> GCObj_class(isolate);
+	GCObj_class
+		.template ctor<int>()
+		.function("get", &GCObj::get);
+
+	context.class_("GCObj", GCObj_class);
+
+	// Rapid create-destroy cycles: 100 cycles of 100 objects each
+	for (int cycle = 0; cycle < 100; ++cycle)
+	{
+		v8::HandleScope cycle_scope(isolate);
+		run_script<int>(context,
+			"for (var i = 0; i < 100; i++) { new GCObj(i); } 0");
+		force_gc(isolate);
+	}
+
+	check_eq("rapid cycles cleanup", GCObj::instance_count.load(), 0);
+}
+
+template<typename Traits>
+void test_gc_stress_inheritance()
+{
+	GCBase::base_count = 0;
+	GCDerived::derived_count = 0;
+
+	v8pp::context context;
+	v8::Isolate* isolate = context.isolate();
+	v8::HandleScope scope(isolate);
+
+	v8pp::class_<GCBase, Traits> base_class(isolate);
+	base_class
+		.template ctor<int>()
+		.function("get_x", &GCBase::get_x);
+
+	v8pp::class_<GCDerived, Traits> derived_class(isolate);
+	derived_class
+		.template ctor<int>()
+		.inherit<GCBase>()
+		.function("get_y", &GCDerived::get_y);
+
+	context.class_("GCBase", base_class);
+	context.class_("GCDerived", derived_class);
+
+	// Create 5k derived objects (each also constructs a base)
+	for (int batch = 0; batch < 50; ++batch)
+	{
+		v8::HandleScope batch_scope(isolate);
+		run_script<int>(context,
+			"for (var i = 0; i < 100; i++) { new GCDerived(i); } 0");
+	}
+
+	force_gc(isolate);
+
+	check_eq("inheritance stress derived cleanup", GCDerived::derived_count.load(), 0);
+	check_eq("inheritance stress base cleanup", GCBase::base_count.load(), 0);
+}
+
+} // anonymous namespace
+
+void test_gc_stress()
+{
+	test_gc_stress_bulk<v8pp::raw_ptr_traits>();
+	test_gc_stress_bulk<v8pp::shared_ptr_traits>();
+
+	test_gc_stress_mixed_lifespan<v8pp::raw_ptr_traits>();
+	test_gc_stress_mixed_lifespan<v8pp::shared_ptr_traits>();
+
+	test_gc_stress_rapid_cycles<v8pp::raw_ptr_traits>();
+	test_gc_stress_rapid_cycles<v8pp::shared_ptr_traits>();
+
+	test_gc_stress_inheritance<v8pp::raw_ptr_traits>();
+	test_gc_stress_inheritance<v8pp::shared_ptr_traits>();
+}

--- a/test/test_overload.cpp
+++ b/test/test_overload.cpp
@@ -1,0 +1,122 @@
+#include "v8pp/class.hpp"
+#include "v8pp/context.hpp"
+#include "v8pp/module.hpp"
+#include "v8pp/overload.hpp"
+
+#include "test.hpp"
+
+// Free functions for overload testing
+static int add_int(int a, int b) { return a + b; }
+static double add_double(double a, double b) { return a + b; }
+static std::string add_string(std::string a, std::string b) { return a + b; }
+static int negate_int(int a) { return -a; }
+
+void test_overload()
+{
+	v8pp::context context;
+	v8::Isolate* isolate = context.isolate();
+	v8::HandleScope scope(isolate);
+
+	// --- Arity-based dispatch ---
+	// f(int) vs f(int, int)
+	context.function("arity_test",
+		static_cast<int(*)(int)>(&negate_int),
+		static_cast<int(*)(int, int)>(&add_int));
+
+	check_eq("overload: arity 1 arg", run_script<int>(context, "arity_test(5)"), -5);
+	check_eq("overload: arity 2 args", run_script<int>(context, "arity_test(3, 7)"), 10);
+
+	// --- Type-based dispatch ---
+	// f(int, int) vs f(string, string)
+	context.function("type_test",
+		static_cast<int(*)(int, int)>(&add_int),
+		static_cast<std::string(*)(std::string, std::string)>(&add_string));
+
+	check_eq("overload: type int", run_script<int>(context, "type_test(10, 20)"), 30);
+	check_eq("overload: type string", run_script<std::string>(context, "type_test('hello', ' world')"), "hello world");
+
+	// --- Mixed arity + type ---
+	// f(int) vs f(double, double)
+	context.function("mixed_test",
+		static_cast<int(*)(int)>(&negate_int),
+		static_cast<double(*)(double, double)>(&add_double));
+
+	check_eq("overload: mixed 1 arg", run_script<int>(context, "mixed_test(42)"), -42);
+	check_eq("overload: mixed 2 args", run_script<double>(context, "mixed_test(1.5, 2.5)"), 4.0);
+
+	// --- Lambda overloads ---
+	context.function("lambda_test",
+		[](int x) { return x * 2; },
+		[](std::string s) { return s + s; });
+
+	check_eq("overload: lambda int", run_script<int>(context, "lambda_test(7)"), 14);
+	check_eq("overload: lambda string", run_script<std::string>(context, "lambda_test('ab')"), "abab");
+
+	// --- No match → error ---
+	check_ex<std::runtime_error>("overload: no match", [&context]
+	{
+		run_script<int>(context, "arity_test()");
+	});
+
+	// --- Module function overloads ---
+	{
+		v8pp::module m(isolate);
+		m.function("compute",
+			[](int x) { return x * x; },
+			[](int x, int y) { return x + y; });
+		context.module("ovl_mod", m);
+
+		check_eq("overload: module 1 arg", run_script<int>(context, "ovl_mod.compute(5)"), 25);
+		check_eq("overload: module 2 args", run_script<int>(context, "ovl_mod.compute(3, 4)"), 7);
+	}
+
+	// --- Overload with defaults ---
+	{
+		context.function("defaults_overload",
+			v8pp::with_defaults([](int a, int b) { return a + b; }, v8pp::defaults(10)),
+			[](std::string s) { return s; });
+
+		check_eq("overload: defaults int both", run_script<int>(context, "defaults_overload(3, 7)"), 10);
+		check_eq("overload: defaults int default", run_script<int>(context, "defaults_overload(5)"), 15);
+		check_eq("overload: defaults string", run_script<std::string>(context, "defaults_overload('hi')"), "hi");
+	}
+
+	// --- Class member overloads ---
+	{
+		struct Calc
+		{
+			int value = 0;
+			int add_one(int n) { value += n; return value; }
+			int add_two(int a, int b) { value += a + b; return value; }
+		};
+
+		v8pp::class_<Calc> calc_class(isolate);
+		calc_class
+			.ctor()
+			.function("add", &Calc::add_one, &Calc::add_two);
+		context.class_("Calc", calc_class);
+
+		check_eq("overload: class 1 arg", run_script<int>(context, "var calc = new Calc(); calc.add(5)"), 5);
+		check_eq("overload: class 2 args", run_script<int>(context, "calc.add(3, 7)"), 15);
+	}
+
+	// --- v8pp::overload<Sig> selector ---
+	{
+		struct Multi
+		{
+			int compute(int x) { return x * 2; }
+			int compute(int x, int y) { return x + y; }
+		};
+
+		v8pp::class_<Multi> multi_class(isolate);
+		multi_class
+			.ctor()
+			.function("compute",
+				v8pp::overload<int(Multi::*)(int)>(&Multi::compute),
+				v8pp::overload<int(Multi::*)(int, int)>(&Multi::compute));
+		context.class_("Multi", multi_class);
+
+		check_eq("overload: selector 1 arg", run_script<int>(context, "var m = new Multi(); m.compute(5)"), 10);
+		check_eq("overload: selector 2 args", run_script<int>(context, "m.compute(3, 4)"), 7);
+	}
+}

--- a/test/test_promise.cpp
+++ b/test/test_promise.cpp
@@ -1,0 +1,206 @@
+#include "v8pp/promise.hpp"
+#include "v8pp/class.hpp"
+#include "v8pp/module.hpp"
+
+#include "test.hpp"
+
+void test_promise()
+{
+	// Test 1: immediate resolve with int
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		context.function("makePromise", [](v8::Isolate* isolate) -> v8pp::promise<int>
+		{
+			v8pp::promise<int> p(isolate);
+			p.resolve(42);
+			return p;
+		});
+
+		// V8 runs microtasks between top-level script evaluations.
+		// First script sets up the .then(), second script reads the result.
+		run_script<std::string>(context,
+			"var intResult = 0;"
+			"makePromise().then(function(v) { intResult = v; });"
+			"''");
+		check_eq("resolved int promise",
+			run_script<int>(context, "intResult"),
+			42);
+	}
+
+	// Test 2: immediate resolve with string
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		context.function("strPromise", [](v8::Isolate* isolate) -> v8pp::promise<std::string>
+		{
+			v8pp::promise<std::string> p(isolate);
+			p.resolve("hello world");
+			return p;
+		});
+
+		run_script<std::string>(context,
+			"var strResult = '';"
+			"strPromise().then(function(v) { strResult = v; });"
+			"''");
+		check_eq("resolved string promise",
+			run_script<std::string>(context, "strResult"),
+			"hello world");
+	}
+
+	// Test 3: immediate reject with error message
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		context.function("rejectPromise", [](v8::Isolate* isolate) -> v8pp::promise<int>
+		{
+			v8pp::promise<int> p(isolate);
+			p.reject("something went wrong");
+			return p;
+		});
+
+		run_script<std::string>(context,
+			"var errMsg = '';"
+			"rejectPromise().catch(function(e) { errMsg = e.message; });"
+			"''");
+		check_eq("rejected promise",
+			run_script<std::string>(context, "errMsg"),
+			"something went wrong");
+	}
+
+	// Test 4: reject with raw V8 value
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		context.function("rejectRaw", [](v8::Isolate* isolate) -> v8pp::promise<int>
+		{
+			v8pp::promise<int> p(isolate);
+			p.reject(v8pp::to_v8(isolate, "raw rejection"));
+			return p;
+		});
+
+		run_script<std::string>(context,
+			"var rawErr = '';"
+			"rejectRaw().catch(function(e) { rawErr = String(e); });"
+			"''");
+		check_eq("raw rejection",
+			run_script<std::string>(context, "rawErr"),
+			"raw rejection");
+	}
+
+	// Test 5: promise<void>
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		context.function("voidPromise", [](v8::Isolate* isolate) -> v8pp::promise<void>
+		{
+			v8pp::promise<void> p(isolate);
+			p.resolve();
+			return p;
+		});
+
+		run_script<std::string>(context,
+			"var voidResult = 'not called';"
+			"voidPromise().then(function() { voidResult = 'called'; });"
+			"''");
+		check_eq("void promise",
+			run_script<std::string>(context, "voidResult"),
+			"called");
+	}
+
+	// Test 6: void promise rejection
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		context.function("voidReject", [](v8::Isolate* isolate) -> v8pp::promise<void>
+		{
+			v8pp::promise<void> p(isolate);
+			p.reject("void error");
+			return p;
+		});
+
+		run_script<std::string>(context,
+			"var voidErr = '';"
+			"voidReject().catch(function(e) { voidErr = e.message; });"
+			"''");
+		check_eq("void promise rejection",
+			run_script<std::string>(context, "voidErr"),
+			"void error");
+	}
+
+	// Test 7: promise with double
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		context.function("piPromise", [](v8::Isolate* isolate) -> v8pp::promise<double>
+		{
+			v8pp::promise<double> p(isolate);
+			p.resolve(3.14159);
+			return p;
+		});
+
+		run_script<std::string>(context,
+			"var piResult = 0;"
+			"piPromise().then(function(v) { piResult = v; });"
+			"''");
+		check_eq("double promise",
+			run_script<double>(context, "piResult"),
+			3.14159);
+	}
+
+	// Test 8: promise chaining
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		context.function("chainPromise", [](v8::Isolate* isolate) -> v8pp::promise<int>
+		{
+			v8pp::promise<int> p(isolate);
+			p.resolve(10);
+			return p;
+		});
+
+		run_script<std::string>(context,
+			"var chainResult = 0;"
+			"chainPromise()"
+			"  .then(function(v) { return v * 2; })"
+			"  .then(function(v) { chainResult = v; });"
+			"''");
+		check_eq("promise chain",
+			run_script<int>(context, "chainResult"),
+			20);
+	}
+
+	// Test 9: verify return type is actually a Promise
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		context.function("isPromiseTest", [](v8::Isolate* isolate) -> v8pp::promise<int>
+		{
+			v8pp::promise<int> p(isolate);
+			p.resolve(1);
+			return p;
+		});
+
+		check_eq("is a Promise",
+			run_script<bool>(context, "isPromiseTest() instanceof Promise"),
+			true);
+	}
+}

--- a/test/test_symbol.cpp
+++ b/test/test_symbol.cpp
@@ -1,0 +1,242 @@
+#include "v8pp/class.hpp"
+#include "v8pp/module.hpp"
+
+#include "test.hpp"
+
+namespace {
+
+struct Widget
+{
+	int value = 42;
+};
+
+struct NumericValue
+{
+	double val;
+	explicit NumericValue(double v) : val(v) {}
+	double to_number(std::string_view) const { return val; }
+};
+
+struct Tag
+{
+	std::string name;
+	explicit Tag(std::string n) : name(std::move(n)) {}
+};
+
+struct NumberList
+{
+	std::vector<int> numbers;
+
+	auto begin() const { return numbers.begin(); }
+	auto end() const { return numbers.end(); }
+};
+
+struct WordList
+{
+	std::vector<std::string> words;
+
+	auto begin() const { return words.begin(); }
+	auto end() const { return words.end(); }
+};
+
+} // namespace
+
+void test_symbol()
+{
+	// Test to_string_tag
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::class_<Widget> widget_class(isolate);
+		widget_class
+			.ctor<>()
+			.var("value", &Widget::value)
+			.to_string_tag("Widget");
+
+		context.class_("Widget", widget_class);
+
+		check_eq("to_string_tag",
+			run_script<std::string>(context,
+				"let w = new Widget(); Object.prototype.toString.call(w)"),
+			"[object Widget]");
+	}
+
+	// Test to_primitive with member function
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::class_<NumericValue> nv_class(isolate);
+		nv_class
+			.ctor<double>()
+			.to_primitive(&NumericValue::to_number);
+
+		context.class_("NumericValue", nv_class);
+
+		check_eq("to_primitive +",
+			run_script<double>(context, "let nv = new NumericValue(10); nv + 5"),
+			15.0);
+
+		check_eq("to_primitive *",
+			run_script<double>(context, "nv * 3"),
+			30.0);
+	}
+
+	// Test to_primitive with lambda
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::class_<Tag> tag_class(isolate);
+		tag_class
+			.ctor<std::string>()
+			.var("name", &Tag::name)
+			.to_primitive([](Tag const& t, std::string_view) -> std::string {
+				return t.name;
+			});
+
+		context.class_("Tag", tag_class);
+
+		check_eq("to_primitive string concat",
+			run_script<std::string>(context,
+				"let t = new Tag('hello'); '' + t"),
+			"hello");
+	}
+
+	// Test iterable with int vector (member begin/end)
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::class_<NumberList> nl_class(isolate);
+		nl_class
+			.ctor<>()
+			.iterable(&NumberList::begin, &NumberList::end);
+
+		context.class_("NumberList", nl_class);
+
+		auto* nl = new NumberList{{1, 2, 3, 4, 5}};
+		auto nl_obj = v8pp::class_<NumberList>::import_external(isolate, nl);
+		v8pp::set_option(isolate, context.isolate()->GetCurrentContext()->Global(), "nl", nl_obj);
+
+		check_eq("for...of sum",
+			run_script<int>(context,
+				"let sum = 0; for (const n of nl) sum += n; sum"),
+			15);
+
+		check_eq("spread to array",
+			run_script<std::string>(context,
+				"JSON.stringify([...nl])"),
+			"[1,2,3,4,5]");
+
+		check_eq("Array.from",
+			run_script<int>(context,
+				"Array.from(nl).length"),
+			5);
+	}
+
+	// Test iterable with string vector
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::class_<WordList> wl_class(isolate);
+		wl_class
+			.ctor<>()
+			.iterable(&WordList::begin, &WordList::end);
+
+		context.class_("WordList", wl_class);
+
+		auto* wl = new WordList{{"hello", "world"}};
+		auto wl_obj = v8pp::class_<WordList>::import_external(isolate, wl);
+		v8pp::set_option(isolate, context.isolate()->GetCurrentContext()->Global(), "wl", wl_obj);
+
+		check_eq("string iterable",
+			run_script<std::string>(context,
+				"let parts = []; for (const w of wl) parts.push(w); parts.join(' ')"),
+			"hello world");
+	}
+
+	// Test iterable with empty container
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::class_<NumberList> nl_class(isolate);
+		nl_class
+			.ctor<>()
+			.iterable(&NumberList::begin, &NumberList::end);
+
+		context.class_("NumberList", nl_class);
+
+		auto* nl = new NumberList{{}};
+		auto nl_obj = v8pp::class_<NumberList>::import_external(isolate, nl);
+		v8pp::set_option(isolate, context.isolate()->GetCurrentContext()->Global(), "empty_nl", nl_obj);
+
+		check_eq("empty iterable",
+			run_script<int>(context,
+				"let count = 0; for (const n of empty_nl) count++; count"),
+			0);
+	}
+
+	// Test iterable with lambda begin/end
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::class_<NumberList> nl_class(isolate);
+		nl_class
+			.ctor<>()
+			.iterable(
+				[](NumberList const& nl) { return nl.numbers.begin(); },
+				[](NumberList const& nl) { return nl.numbers.end(); });
+
+		context.class_("NumberList", nl_class);
+
+		auto* nl = new NumberList{{10, 20, 30}};
+		auto nl_obj = v8pp::class_<NumberList>::import_external(isolate, nl);
+		v8pp::set_option(isolate, context.isolate()->GetCurrentContext()->Global(), "nl2", nl_obj);
+
+		check_eq("lambda iterable",
+			run_script<int>(context,
+				"let s = 0; for (const n of nl2) s += n; s"),
+			60);
+	}
+
+	// Test combined: to_string_tag + iterable
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::class_<NumberList> nl_class(isolate);
+		nl_class
+			.ctor<>()
+			.to_string_tag("NumberList")
+			.iterable(&NumberList::begin, &NumberList::end);
+
+		context.class_("NumberList", nl_class);
+
+		auto* nl = new NumberList{{1, 2}};
+		auto nl_obj = v8pp::class_<NumberList>::import_external(isolate, nl);
+		v8pp::set_option(isolate, context.isolate()->GetCurrentContext()->Global(), "nl3", nl_obj);
+
+		check_eq("tag + iterable tag",
+			run_script<std::string>(context,
+				"Object.prototype.toString.call(nl3)"),
+			"[object NumberList]");
+
+		check_eq("tag + iterable spread",
+			run_script<int>(context,
+				"[...nl3].reduce((a, b) => a + b, 0)"),
+			3);
+	}
+}

--- a/test/test_thread_safety.cpp
+++ b/test/test_thread_safety.cpp
@@ -1,0 +1,327 @@
+#include "v8pp/class.hpp"
+#include "v8pp/context.hpp"
+
+#include "test.hpp"
+
+#include <atomic>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+struct ThreadObj
+{
+	static std::atomic<int> total_created;
+	static std::atomic<int> total_destroyed;
+	int value;
+
+	explicit ThreadObj(int v = 0) : value(v) { ++total_created; }
+	~ThreadObj() { ++total_destroyed; }
+
+	int get() const { return value; }
+	int add(int x) const { return value + x; }
+};
+
+std::atomic<int> ThreadObj::total_created = 0;
+std::atomic<int> ThreadObj::total_destroyed = 0;
+
+struct SharedObj
+{
+	std::atomic<int> access_count{0};
+	int value;
+
+	explicit SharedObj(int v = 0) : value(v) {}
+
+	int get()
+	{
+		++access_count;
+		return value;
+	}
+};
+
+void force_gc(v8::Isolate* isolate)
+{
+	isolate->RequestGarbageCollectionForTesting(
+		v8::Isolate::GarbageCollectionType::kFullGarbageCollection);
+	isolate->RequestGarbageCollectionForTesting(
+		v8::Isolate::GarbageCollectionType::kFullGarbageCollection);
+}
+
+//
+// Test: multiple threads, each with own isolate and context
+//
+
+void test_concurrent_isolates()
+{
+	ThreadObj::total_created = 0;
+	ThreadObj::total_destroyed = 0;
+
+	constexpr int num_threads = 4;
+	constexpr int objects_per_thread = 1000;
+	std::atomic<int> errors{0};
+
+	auto worker = [&errors](int thread_id)
+	{
+		try
+		{
+			v8pp::context context;
+			v8::Isolate* isolate = context.isolate();
+			v8::HandleScope scope(isolate);
+
+			v8pp::class_<ThreadObj, v8pp::raw_ptr_traits> obj_class(isolate);
+			obj_class
+				.ctor<int>()
+				.function("get", &ThreadObj::get)
+				.function("add", &ThreadObj::add);
+
+			context.class_("ThreadObj", obj_class);
+
+			// Create objects in batches
+			for (int batch = 0; batch < objects_per_thread / 100; ++batch)
+			{
+				v8::HandleScope batch_scope(isolate);
+				std::string script =
+					"for (var i = 0; i < 100; i++) {"
+					"  var o = new ThreadObj(" + std::to_string(thread_id * 1000 + batch * 100) + " + i);"
+					"  o.add(1);"
+					"} 0";
+				run_script<int>(context, script.c_str());
+			}
+
+			force_gc(isolate);
+		}
+		catch (std::exception const& ex)
+		{
+			++errors;
+			std::cerr << "Thread " << thread_id << " error: " << ex.what() << '\n';
+		}
+	};
+
+	std::vector<std::thread> threads;
+	threads.reserve(num_threads);
+	for (int i = 0; i < num_threads; ++i)
+	{
+		threads.emplace_back(worker, i);
+	}
+
+	for (auto& t : threads)
+	{
+		t.join();
+	}
+
+	check_eq("concurrent isolates no errors", errors.load(), 0);
+	check_eq("concurrent isolates all cleaned up",
+		ThreadObj::total_created.load(), ThreadObj::total_destroyed.load());
+}
+
+//
+// Test: cross-isolate shared_ptr (sequential)
+//
+// Wrap the same shared_ptr object in two different isolates sequentially.
+//
+
+void test_cross_isolate_shared_ptr_sequential()
+{
+	auto shared = std::make_shared<SharedObj>(42);
+	check_eq("initial use_count", shared.use_count(), 1L);
+
+	// Isolate A
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::class_<SharedObj, v8pp::shared_ptr_traits> obj_class(isolate);
+		obj_class
+			.function("get", &SharedObj::get);
+
+		context.class_("SharedObj", obj_class);
+
+		v8::Local<v8::Object> js_obj =
+			v8pp::class_<SharedObj, v8pp::shared_ptr_traits>::reference_external(isolate, shared);
+		check("isolate A wrap", !js_obj.IsEmpty());
+
+		// Use the object from JS
+		v8pp::set_option(isolate, context.global(), "obj", js_obj);
+		check_eq("isolate A get", run_script<int>(context, "obj.get()"), 42);
+
+		v8pp::class_<SharedObj, v8pp::shared_ptr_traits>::unreference_external(isolate, shared);
+	}
+
+	// Object should still be alive (main thread holds shared_ptr)
+	check_eq("shared survives isolate A", shared->value, 42);
+
+	// Isolate B
+	{
+		v8pp::context context;
+		v8::Isolate* isolate = context.isolate();
+		v8::HandleScope scope(isolate);
+
+		v8pp::class_<SharedObj, v8pp::shared_ptr_traits> obj_class(isolate);
+		obj_class
+			.function("get", &SharedObj::get);
+
+		context.class_("SharedObj", obj_class);
+
+		v8::Local<v8::Object> js_obj =
+			v8pp::class_<SharedObj, v8pp::shared_ptr_traits>::reference_external(isolate, shared);
+		check("isolate B wrap", !js_obj.IsEmpty());
+
+		v8pp::set_option(isolate, context.global(), "obj", js_obj);
+		check_eq("isolate B get", run_script<int>(context, "obj.get()"), 42);
+
+		v8pp::class_<SharedObj, v8pp::shared_ptr_traits>::unreference_external(isolate, shared);
+	}
+
+	// Only main thread's copy should remain
+	check_eq("shared survives both isolates", shared->value, 42);
+	check_eq("final use_count", shared.use_count(), 1L);
+	check_eq("total access count", shared->access_count.load(), 2);
+}
+
+//
+// Test: cross-isolate shared_ptr (concurrent)
+//
+// Multiple threads each wrap the same shared_ptr in their own isolate.
+//
+
+void test_cross_isolate_shared_ptr_concurrent()
+{
+	auto shared = std::make_shared<SharedObj>(99);
+
+	constexpr int num_threads = 4;
+	std::atomic<int> errors{0};
+
+	auto worker = [&shared, &errors](int)
+	{
+		try
+		{
+			// Each thread gets its own copy of the shared_ptr
+			auto local_copy = shared;
+
+			v8pp::context context;
+			v8::Isolate* isolate = context.isolate();
+			v8::HandleScope scope(isolate);
+
+			v8pp::class_<SharedObj, v8pp::shared_ptr_traits> obj_class(isolate);
+			obj_class
+				.function("get", &SharedObj::get);
+
+			context.class_("SharedObj", obj_class);
+
+			v8::Local<v8::Object> js_obj =
+				v8pp::class_<SharedObj, v8pp::shared_ptr_traits>::reference_external(isolate, local_copy);
+
+			v8pp::set_option(isolate, context.global(), "obj", js_obj);
+
+			int result = run_script<int>(context, "obj.get()");
+			if (result != 99)
+			{
+				++errors;
+			}
+
+			v8pp::class_<SharedObj, v8pp::shared_ptr_traits>::unreference_external(isolate, local_copy);
+		}
+		catch (std::exception const& ex)
+		{
+			++errors;
+			std::cerr << "Thread error: " << ex.what() << '\n';
+		}
+	};
+
+	std::vector<std::thread> threads;
+	threads.reserve(num_threads);
+	for (int i = 0; i < num_threads; ++i)
+	{
+		threads.emplace_back(worker, i);
+	}
+
+	for (auto& t : threads)
+	{
+		t.join();
+	}
+
+	check_eq("concurrent shared_ptr no errors", errors.load(), 0);
+	check_eq("concurrent shared_ptr use_count", shared.use_count(), 1L);
+	check("concurrent shared_ptr accessed", shared->access_count.load() >= num_threads);
+}
+
+//
+// Test: isolate independence
+//
+// Two threads register classes with the same name but different types.
+// Each should only see its own registration.
+//
+
+struct IsoTypeA
+{
+	int get() const { return 111; }
+};
+
+struct IsoTypeB
+{
+	int get() const { return 222; }
+};
+
+void test_isolate_independence()
+{
+	std::atomic<int> errors{0};
+	std::atomic<int> result_a{0};
+	std::atomic<int> result_b{0};
+
+	auto worker_a = [&]()
+	{
+		try
+		{
+			v8pp::context context;
+			v8::Isolate* isolate = context.isolate();
+			v8::HandleScope scope(isolate);
+
+			v8pp::class_<IsoTypeA, v8pp::raw_ptr_traits> cls(isolate);
+			cls.ctor<>().function("get", &IsoTypeA::get);
+			context.class_("MyClass", cls);
+
+			result_a = run_script<int>(context, "var x = new MyClass(); x.get()");
+		}
+		catch (std::exception const&) { ++errors; }
+	};
+
+	auto worker_b = [&]()
+	{
+		try
+		{
+			v8pp::context context;
+			v8::Isolate* isolate = context.isolate();
+			v8::HandleScope scope(isolate);
+
+			v8pp::class_<IsoTypeB, v8pp::raw_ptr_traits> cls(isolate);
+			cls.ctor<>().function("get", &IsoTypeB::get);
+			context.class_("MyClass", cls);
+
+			result_b = run_script<int>(context, "var x = new MyClass(); x.get()");
+		}
+		catch (std::exception const&) { ++errors; }
+	};
+
+	std::thread ta(worker_a);
+	std::thread tb(worker_b);
+	ta.join();
+	tb.join();
+
+	check_eq("isolate independence no errors", errors.load(), 0);
+	check_eq("isolate A sees its own type", result_a.load(), 111);
+	check_eq("isolate B sees its own type", result_b.load(), 222);
+}
+
+} // anonymous namespace
+
+void test_thread_safety()
+{
+	test_concurrent_isolates();
+	test_cross_isolate_shared_ptr_sequential();
+	test_cross_isolate_shared_ptr_concurrent();
+	test_isolate_independence();
+}

--- a/test/test_type_info.cpp
+++ b/test/test_type_info.cpp
@@ -9,9 +9,46 @@ void test_type_info()
 {
 	using v8pp::detail::type_id;
 
-	check_eq("type_id", type_id<int>().name(), "int");
-	check_eq("type_id", type_id<bool>().name(), "bool");
-	check_eq("type_id", type_id<some_struct>().name(), "some_struct");
-	check_eq("type_id", type_id<test::some_class>().name(), "test::some_class");
-	check_eq("type_id", type_id<other_class>().name(), "test::some_class");
+#if V8PP_PRETTIFY_TYPENAMES
+	// When prettification is enabled, we get clean type names
+	check_eq("type_id int", type_id<int>().name(), "int");
+	check_eq("type_id bool", type_id<bool>().name(), "bool");
+	check_eq("type_id some_struct", type_id<some_struct>().name(), "some_struct");
+	check_eq("type_id test::some_class", type_id<test::some_class>().name(), "test::some_class");
+	check_eq("type_id other_class", type_id<other_class>().name(), "test::some_class");
+#else
+	// When prettification is disabled, names are raw compiler output.
+	// Verify names are non-empty and contain the type name substring.
+	check("type_id<int> non-empty", !type_id<int>().name().empty());
+	check("type_id<bool> non-empty", !type_id<bool>().name().empty());
+	check("type_id<some_struct> non-empty", !type_id<some_struct>().name().empty());
+
+	check("type_id<int> contains 'int'",
+		type_id<int>().name().find("int") != std::string_view::npos);
+	check("type_id<bool> contains 'bool'",
+		type_id<bool>().name().find("bool") != std::string_view::npos);
+	check("type_id<some_struct> contains 'some_struct'",
+		type_id<some_struct>().name().find("some_struct") != std::string_view::npos);
+	check("type_id<some_class> contains 'some_class'",
+		type_id<test::some_class>().name().find("some_class") != std::string_view::npos);
+#endif
+
+	// These checks must pass regardless of V8PP_PRETTIFY_TYPENAMES
+
+	// IDs are unique per type
+	check("int != bool", type_id<int>() != type_id<bool>());
+	check("int != some_struct", type_id<int>() != type_id<some_struct>());
+	check("bool != some_struct", type_id<bool>() != type_id<some_struct>());
+	check("some_struct != some_class", type_id<some_struct>() != type_id<test::some_class>());
+
+	// IDs are stable (same call returns same ID)
+	check("int == int", type_id<int>() == type_id<int>());
+	check("some_struct == some_struct", type_id<some_struct>() == type_id<some_struct>());
+
+	// Type alias produces same ID as original type
+	check("other_class == some_class", type_id<other_class>() == type_id<test::some_class>());
+
+	// ID values are non-zero
+	check("int id nonzero", type_id<int>().id() != 0);
+	check("bool id nonzero", type_id<bool>().id() != 0);
 }

--- a/v8pp/CMakeLists.txt
+++ b/v8pp/CMakeLists.txt
@@ -25,6 +25,7 @@ set(V8PP_HEADERS
 	call_v8.hpp
 	class.hpp
 	context.hpp
+	context_store.hpp
 	convert.hpp
 	function.hpp
 	json.hpp
@@ -43,6 +44,7 @@ set(V8PP_HEADERS
 if(V8PP_HEADER_ONLY)
 	list(APPEND V8PP_HEADERS
 		class.ipp
+		context_store.ipp
 		json.ipp
 		throw_ex.ipp
 		version.ipp
@@ -52,6 +54,7 @@ else()
 	set(V8PP_SOURCES
 		class.cpp
 		context.cpp
+		context_store.cpp
 		convert.cpp
 		json.cpp
 		throw_ex.cpp

--- a/v8pp/CMakeLists.txt
+++ b/v8pp/CMakeLists.txt
@@ -30,6 +30,8 @@ set(V8PP_HEADERS
 	json.hpp
 	module.hpp
 	object.hpp
+	overload.hpp
+	promise.hpp
 	property.hpp
 	ptr_traits.hpp
 	throw_ex.hpp

--- a/v8pp/CMakeLists.txt
+++ b/v8pp/CMakeLists.txt
@@ -91,9 +91,6 @@ else()
 	endif()
 endif()
 
-if(V8PP_PRETTIFY_TYPENAMES)
-	target_compile_definitions(v8pp PRIVATE V8PP_PRETTIFY_TYPENAMES=1)
-endif()
 
 #source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${V8PP_HEADERS} ${V8PP_SOURCES})
 

--- a/v8pp/CMakeLists.txt
+++ b/v8pp/CMakeLists.txt
@@ -2,7 +2,32 @@
 
 include(GNUInstallDirs)
 
-if(DEFINED VCPKG_TARGET_TRIPLET)
+if(TARGET V8::V8)
+	message(STATUS "Using existing V8::V8 target")
+elseif(DEFINED CUSTOM_V8_LIB_PATH)
+	add_library(CustomV8 INTERFACE)
+	add_library(V8::V8 ALIAS CustomV8)
+	if(DEFINED CUSTOM_V8_INCLUDE_PATH)
+		target_include_directories(CustomV8 INTERFACE
+			$<BUILD_INTERFACE:${CUSTOM_V8_INCLUDE_PATH}>
+		)
+	endif()
+	get_filename_component(_v8_ext "${CUSTOM_V8_LIB_PATH}" EXT)
+	if("${_v8_ext}" STREQUAL ".a" OR "${_v8_ext}" STREQUAL ".so" OR "${_v8_ext}" STREQUAL ".lib" OR "${_v8_ext}" STREQUAL ".dylib")
+		target_link_libraries(CustomV8 INTERFACE "${CUSTOM_V8_LIB_PATH}")
+	else()
+		# directory containing individual V8 static libs
+		target_link_libraries(CustomV8 INTERFACE
+			"${CUSTOM_V8_LIB_PATH}/libv8_libbase.a"
+			"${CUSTOM_V8_LIB_PATH}/libv8_libplatform.a"
+			"${CUSTOM_V8_LIB_PATH}/libv8_monolith.a"
+		)
+	endif()
+	if(WIN32)
+		target_link_libraries(CustomV8 INTERFACE winmm dbghelp)
+	endif()
+	message(STATUS "Using custom V8 from ${CUSTOM_V8_LIB_PATH}")
+elseif(DEFINED VCPKG_TARGET_TRIPLET)
 	find_package(V8 CONFIG REQUIRED)
 else()
 	list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
@@ -104,6 +129,9 @@ write_basic_package_version_file("${PROJECT_BINARY_DIR}/ConfigVersion.cmake" COM
 configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in" "${PROJECT_BINARY_DIR}/Config.cmake"
 	INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/v8pp/cmake)
 
+if(TARGET CustomV8)
+	install(TARGETS CustomV8 EXPORT ${targets_export_name})
+endif()
 install(TARGETS v8pp EXPORT ${targets_export_name})
 install(EXPORT ${targets_export_name}
 	NAMESPACE v8pp::

--- a/v8pp/CMakeLists.txt
+++ b/v8pp/CMakeLists.txt
@@ -62,13 +62,12 @@ else()
 	)
 endif()
 
-#set(CMAKE_CXX_RTTI OFF)
 if(MSVC)
 	set(V8PP_COMPILE_OPTIONS /GR- /EHsc /permissive- /W4)
 	# disable specific warnings
 	list(APPEND V8PP_COMPILE_OPTIONS /wd4190)
 	# set warning level 3 for system headers
-	list(APPEND V8PP_COMPILE_OPTIONS /experimental:external /external:anglebrackets /external:W3)
+	list(APPEND V8PP_COMPILE_OPTIONS /external:anglebrackets /external:W3)
 else()
 	set(V8PP_COMPILE_OPTIONS -frtti -fexceptions -Wall -Wextra -Wpedantic)
 endif()
@@ -95,9 +94,6 @@ else()
 		target_link_libraries(v8pp PUBLIC ${CMAKE_DL_LIBS})
 	endif()
 endif()
-
-
-#source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${V8PP_HEADERS} ${V8PP_SOURCES})
 
 # Install
 include(CMakePackageConfigHelpers)

--- a/v8pp/call_from_v8.hpp
+++ b/v8pp/call_from_v8.hpp
@@ -8,6 +8,30 @@
 #include "v8pp/convert.hpp"
 #include "v8pp/utility.hpp"
 
+namespace v8pp {
+
+/// Tag type holding default parameter values for trailing arguments.
+/// Defaults fill from the right side of the parameter list, like C++ defaults.
+/// Usage: v8pp::defaults(1.0f, "black") for the last 2 parameters.
+template<typename... Defs>
+struct defaults
+{
+	std::tuple<Defs...> values;
+	explicit constexpr defaults(Defs... args) : values(std::move(args)...) {}
+};
+
+template<typename... Defs>
+defaults(Defs...) -> defaults<Defs...>;
+
+/// Type trait to detect defaults<...>
+template<typename T>
+struct is_defaults : std::false_type {};
+
+template<typename... Defs>
+struct is_defaults<defaults<Defs...>> : std::true_type {};
+
+} // namespace v8pp
+
 namespace v8pp::detail {
 
 template<typename>
@@ -80,6 +104,7 @@ decltype(auto) call_from_v8_impl(F&& func, v8::FunctionCallbackInfo<v8::Value> c
 }
 
 template<typename Traits, typename F, typename... ObjArg>
+	requires (sizeof...(ObjArg) == 0 || (!v8pp::is_defaults<std::remove_cvref_t<ObjArg>>::value && ...))
 decltype(auto) call_from_v8(F&& func, v8::FunctionCallbackInfo<v8::Value> const& args, ObjArg&... obj)
 {
 	constexpr bool with_isolate = is_first_arg_isolate<F>;
@@ -117,6 +142,99 @@ decltype(auto) call_from_v8(F&& func, v8::FunctionCallbackInfo<v8::Value> const&
 		{
 			return (call_from_v8_impl<Traits>(std::forward<F>(func), args,
 				call_traits{}, indices{}, obj...));
+		}
+	}
+}
+
+/// Extract a single argument: from V8 args if provided, from defaults tuple otherwise.
+/// DefaultsStart is the first arg index that has a default value.
+template<typename Traits, typename CallTraits, size_t Index, size_t DefaultsStart,
+	typename DefaultsTuple>
+decltype(auto) arg_or_default(v8::FunctionCallbackInfo<v8::Value> const& args,
+	DefaultsTuple const& defaults_tuple)
+{
+	if constexpr (Index < DefaultsStart)
+	{
+		// No default available — always convert from V8
+		return CallTraits::template arg_from_v8<Index + CallTraits::offset, Traits>(args);
+	}
+	else
+	{
+		// This parameter has a default value available.
+		// Both branches must return the same value_type (arg_from_v8 may return a
+		// proxy type like convertible_string, so explicit cast is needed).
+		using arg_type = typename CallTraits::template arg_type<Index + CallTraits::offset>;
+		using value_type = std::remove_cv_t<std::remove_reference_t<arg_type>>;
+
+		if (static_cast<size_t>(args.Length()) <= Index)
+		{
+			constexpr size_t def_index = Index - DefaultsStart;
+			return static_cast<value_type>(std::get<def_index>(defaults_tuple));
+		}
+		return static_cast<value_type>(
+			CallTraits::template arg_from_v8<Index + CallTraits::offset, Traits>(args));
+	}
+}
+
+template<typename Traits, typename F, typename CallTraits, typename DefaultsTuple,
+	size_t DefaultsStart, size_t... Indices, typename... ObjArg>
+decltype(auto) call_from_v8_defaults_impl(F&& func, v8::FunctionCallbackInfo<v8::Value> const& args,
+	DefaultsTuple const& defaults_tuple,
+	CallTraits, std::index_sequence<Indices...>, ObjArg&&... obj)
+{
+	(void)args;
+	return (std::invoke(func, std::forward<ObjArg>(obj)...,
+		arg_or_default<Traits, CallTraits, Indices, DefaultsStart>(args, defaults_tuple)...));
+}
+
+/// call_from_v8 with default parameter values
+template<typename Traits, typename F, typename... Defs, typename... ObjArg>
+decltype(auto) call_from_v8(F&& func, v8::FunctionCallbackInfo<v8::Value> const& args,
+	v8pp::defaults<Defs...> const& defs, ObjArg&... obj)
+{
+	constexpr bool with_isolate = is_first_arg_isolate<F>;
+
+	if constexpr (is_direct_args<F, with_isolate>)
+	{
+		// direct FunctionCallbackInfo — defaults don't apply
+		if constexpr (with_isolate)
+			return (std::invoke(func, obj..., args.GetIsolate(), args));
+		else
+			return (std::invoke(func, obj..., args));
+	}
+	else
+	{
+		using call_traits = call_from_v8_traits<F, with_isolate>;
+		using indices = std::make_index_sequence<call_traits::arg_count>;
+
+		constexpr size_t num_defaults = sizeof...(Defs);
+		static_assert(num_defaults <= call_traits::arg_count,
+			"More defaults than function parameters");
+
+		constexpr size_t defaults_start = call_traits::arg_count - num_defaults;
+		constexpr size_t min_args = defaults_start - call_traits::optional_arg_count;
+
+		size_t const arg_count = args.Length();
+		if (arg_count > call_traits::arg_count || arg_count < min_args)
+		{
+			throw std::runtime_error(
+				"Argument count does not match function definition. Expected " +
+				std::to_string(min_args) + ".." +
+				std::to_string(call_traits::arg_count) + " but got " +
+				std::to_string(arg_count));
+		}
+
+		if constexpr (with_isolate)
+		{
+			return (call_from_v8_defaults_impl<Traits, F, call_traits, decltype(defs.values),
+				defaults_start>(std::forward<F>(func), args,
+				defs.values, call_traits{}, indices{}, obj..., args.GetIsolate()));
+		}
+		else
+		{
+			return (call_from_v8_defaults_impl<Traits, F, call_traits, decltype(defs.values),
+				defaults_start>(std::forward<F>(func), args,
+				defs.values, call_traits{}, indices{}, obj...));
 		}
 	}
 }

--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -316,7 +316,13 @@ public:
 			wrapped_fun = wrap_function_template<Function, Traits>(isolate(), std::forward<Function>(func));
 		}
 
-		class_info_.js_function_template()->PrototypeTemplate()->Set(v8_name, wrapped_fun, attr);
+		v8::Local<v8::FunctionTemplate> js_func = class_info_.js_function_template();
+		js_func->PrototypeTemplate()->Set(v8_name, wrapped_fun, attr);
+		if constexpr (!is_mem_fun)
+		{
+			// non-member functions are also accessible on the constructor (e.g. X.static_fun())
+			js_func->Set(v8_name, wrapped_fun, attr);
+		}
 		return *this;
 	}
 

--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -21,12 +21,20 @@ namespace v8pp::detail {
 
 struct class_info
 {
+	static constexpr uint32_t kMagic = 0xC1A5517F;
+
+	uint32_t const magic = kMagic;
 	type_info const type;
 	type_info const traits;
 
 	class_info(type_info const& type, type_info const& traits);
 
-	virtual ~class_info() = default; // make virtual to delete derived object_registry
+	virtual ~class_info()
+	{
+		const_cast<uint32_t&>(magic) = 0;
+	}
+
+	bool is_valid() const { return magic == kMagic; }
 
 	std::string class_name() const;
 };

--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -586,7 +586,7 @@ public:
 		class_info_.js_function_template()
 				->InstanceTemplate()
 				->SetNativeDataProperty(v8_name, getter, setter, data,
-					v8::PropertyAttribute(v8::DontDelete), v8::DEFAULT,
+					v8::PropertyAttribute(v8::DontDelete),
 					v8::SideEffectType::kHasNoSideEffect,
 					v8::SideEffectType::kHasSideEffectToReceiver);
 #else
@@ -636,7 +636,7 @@ public:
 #if V8_MAJOR_VERSION > 12 || (V8_MAJOR_VERSION == 12 && V8_MINOR_VERSION >= 9)
 		// SetAccessor removed from ObjectTemplate in V8 12.9+
 		class_info_.js_function_template()->InstanceTemplate()->SetNativeDataProperty(v8_name, getter, setter, data,
-			v8::PropertyAttribute(v8::DontDelete), v8::DEFAULT,
+			v8::PropertyAttribute(v8::DontDelete),
 			v8::SideEffectType::kHasNoSideEffect, setter_effect);
 #else
 		class_info_.js_function_template()->PrototypeTemplate()->SetAccessor(v8_name, getter, setter, data,

--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -428,9 +428,13 @@ public:
 	template<typename Value>
 	class_& static_(std::string_view const& name, Value const& value, bool readonly = false)
 	{
-		v8::HandleScope scope(isolate());
+		v8::Isolate* iso = isolate();
+		v8::HandleScope scope(iso);
+		v8::Local<v8::Context> context = iso->GetCurrentContext();
 
-		class_info_.js_function_template()->GetFunction(isolate()->GetCurrentContext()).ToLocalChecked()->DefineOwnProperty(isolate()->GetCurrentContext(), v8pp::to_v8(isolate(), name), to_v8(isolate(), value), v8::PropertyAttribute(v8::DontDelete | (readonly ? v8::ReadOnly : 0))).FromJust();
+		class_info_.js_function_template()->GetFunction(context).ToLocalChecked()
+			->DefineOwnProperty(context, v8pp::to_v8(iso, name), to_v8(iso, value),
+				v8::PropertyAttribute(v8::DontDelete | (readonly ? v8::ReadOnly : 0))).FromJust();
 		return *this;
 	}
 

--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -657,10 +657,6 @@ public:
 
 		static_assert(std::is_member_function_pointer<GetFunction>::value || detail::is_callable<Getter>::value, "GetFunction must be callable");
 
-		using GetClass = std::conditional_t<detail::function_with_object<Getter, T>, T, detail::none>;
-
-		using property_type = v8pp::property<Getter, detail::none, GetClass, detail::none>;
-
 		v8::HandleScope scope(isolate());
 
 		// Store the native function for the constant property in object_registry

--- a/v8pp/class.ipp
+++ b/v8pp/class.ipp
@@ -217,8 +217,11 @@ V8PP_IMPL v8::Local<v8::Object> object_registry<Traits>::wrap_this(v8::Local<v8:
 	pobj.SetWeak(this, [](v8::WeakCallbackInfo<object_registry> const& data)
 		{
 			object_id object = data.GetInternalField(0);
-			object_registry* this_ = static_cast<object_registry*>(data.GetInternalField(1));
-			this_->remove_object(object);
+			auto this_ = static_cast<object_registry*>(data.GetInternalField(1));
+			if (this_ && this_->is_valid())
+			{
+				this_->remove_object(object);
+			}
 		}, v8::WeakCallbackType::kInternalFields);
 	objects_.emplace(object, wrapped_object{ std::move(pobj), size });
 	apply_const_properties(isolate_, obj, object);
@@ -261,8 +264,11 @@ V8PP_IMPL v8::Local<v8::Object> object_registry<Traits>::wrap_object(pointer_typ
 		pobj.SetWeak(this, [](v8::WeakCallbackInfo<object_registry> const& data)
 			{
 				object_id object = data.GetInternalField(0);
-				object_registry* this_ = static_cast<object_registry*>(data.GetInternalField(1));
-				this_->remove_object(object);
+				auto this_ = static_cast<object_registry*>(data.GetInternalField(1));
+				if (this_ && this_->is_valid())
+				{
+					this_->remove_object(object);
+				}
 			}, v8::WeakCallbackType::kInternalFields);
 		objects_.emplace(object, wrapped_object{ std::move(pobj), size });
 		apply_const_properties(isolate_, obj, object);
@@ -294,9 +300,46 @@ object_registry<Traits>::unwrap_object(v8::Local<v8::Value> value)
 {
 	v8::HandleScope scope(isolate_);
 
-	while (value->IsObject())
+	if (!value->IsObject())
 	{
-		v8::Local<v8::Object> obj = value.As<v8::Object>();
+		return nullptr;
+	}
+
+	v8::Local<v8::Object> obj = value.As<v8::Object>();
+
+	// Fast path: check the object itself (most common case)
+	if (obj->InternalFieldCount() == 2)
+	{
+		object_id id = obj->GetAlignedPointerFromInternalField(0);
+		if (id)
+		{
+			auto registry = static_cast<object_registry*>(
+				obj->GetAlignedPointerFromInternalField(1));
+			if (registry && registry->is_valid())
+			{
+				pointer_type ptr = registry->find_object(id, type);
+				if (ptr)
+				{
+					return ptr;
+				}
+			}
+		}
+	}
+
+	// Slow path: walk prototype chain with depth limit (for inheritance)
+	constexpr int kMaxPrototypeDepth = 16;
+	for (int depth = 0; depth < kMaxPrototypeDepth; ++depth)
+	{
+#if V8_MAJOR_VERSION > 12 || (V8_MAJOR_VERSION == 12 && V8_MINOR_VERSION >= 9)
+		value = obj->GetPrototypeV2();
+#else
+		value = obj->GetPrototype();
+#endif
+		if (!value->IsObject())
+		{
+			break;
+		}
+		obj = value.As<v8::Object>();
 		if (obj->InternalFieldCount() == 2)
 		{
 			object_id id = obj->GetAlignedPointerFromInternalField(0);
@@ -304,7 +347,7 @@ object_registry<Traits>::unwrap_object(v8::Local<v8::Value> value)
 			{
 				auto registry = static_cast<object_registry*>(
 					obj->GetAlignedPointerFromInternalField(1));
-				if (registry)
+				if (registry && registry->is_valid())
 				{
 					pointer_type ptr = registry->find_object(id, type);
 					if (ptr)
@@ -314,11 +357,6 @@ object_registry<Traits>::unwrap_object(v8::Local<v8::Value> value)
 				}
 			}
 		}
-#if V8_MAJOR_VERSION > 12 || (V8_MAJOR_VERSION == 12 && V8_MINOR_VERSION >= 9)
-		value = obj->GetPrototypeV2();
-#else
-		value = obj->GetPrototype();
-#endif
 	}
 	return nullptr;
 }

--- a/v8pp/class.ipp
+++ b/v8pp/class.ipp
@@ -52,6 +52,11 @@ V8PP_IMPL object_registry<Traits>::object_registry(v8::Isolate* isolate, type_in
 		[](v8::FunctionCallbackInfo<v8::Value> const& args)
 		{
 			v8::Isolate* isolate = args.GetIsolate();
+			if (!args.IsConstructCall())
+			{
+				args.GetReturnValue().Set(throw_ex(isolate, "must be called with new"));
+				return;
+			}
 			object_registry* this_ = external_data::get<object_registry*>(args.Data());
 			try
 			{

--- a/v8pp/config.hpp.in
+++ b/v8pp/config.hpp.in
@@ -36,13 +36,17 @@
 v8::Local<v8::Value> V8PP_PLUGIN_INIT_PROC_NAME(isolate)
 
 #ifndef V8PP_HEADER_ONLY
-#define V8PP_HEADER_ONLY @V8PP_HEADER_ONLY@
+#cmakedefine01 V8PP_HEADER_ONLY
 #endif
 
 #if V8PP_HEADER_ONLY
 #define V8PP_IMPL inline
 #else
 #define V8PP_IMPL
+#endif
+
+#ifndef V8PP_PRETTIFY_TYPENAMES
+#cmakedefine01 V8PP_PRETTIFY_TYPENAMES
 #endif
 
 #define V8PP_STRINGIZE(s)  V8PP_STRINGIZE0(s)

--- a/v8pp/context.cpp
+++ b/v8pp/context.cpp
@@ -129,33 +129,10 @@ void context::run_file(v8::FunctionCallbackInfo<v8::Value> const& args)
 	args.GetReturnValue().Set(scope.Escape(result));
 }
 
-#if V8_MAJOR_VERSION < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 4)
-struct array_buffer_allocator : v8::ArrayBuffer::Allocator
-{
-	void* Allocate(size_t length)
-	{
-		return calloc(length, 1);
-	}
-	void* AllocateUninitialized(size_t length)
-	{
-		return malloc(length);
-	}
-	void Free(void* data, size_t length)
-	{
-		free(data);
-		(void)length;
-	}
-};
-#endif
-
 v8::Isolate* context::create_isolate(v8::ArrayBuffer::Allocator* allocator)
 {
 	v8::Isolate::CreateParams create_params;
-#if V8_MAJOR_VERSION < 5 || (V8_MAJOR_VERSION == 5 && V8_MINOR_VERSION < 4)
-	create_params.array_buffer_allocator = allocator ? allocator : new array_buffer_allocator;
-#else
 	create_params.array_buffer_allocator = allocator ? allocator : v8::ArrayBuffer::Allocator::NewDefaultAllocator();
-#endif
 
 	return v8::Isolate::New(create_params);
 }

--- a/v8pp/context.hpp
+++ b/v8pp/context.hpp
@@ -96,7 +96,7 @@ public:
 	context& class_(std::string_view name, v8pp::class_<T, Traits>& cl)
 	{
 		v8::HandleScope scope(isolate_);
-		cl.class_function_template()->SetClassName(v8pp::to_v8(isolate_, name));
+		cl.class_function_template()->SetClassName(v8pp::to_v8_name(isolate_, name));
 		return value(name, cl.js_function_template()->GetFunction(isolate_->GetCurrentContext()).ToLocalChecked());
 	}
 

--- a/v8pp/context.hpp
+++ b/v8pp/context.hpp
@@ -7,6 +7,7 @@
 
 #include "v8pp/convert.hpp"
 #include "v8pp/function.hpp"
+#include "v8pp/overload.hpp"
 
 namespace v8pp {
 
@@ -84,11 +85,38 @@ public:
 
 	/// Set functions to the context global object
 	template<typename Function, typename Traits = raw_ptr_traits>
+		requires detail::is_callable<std::decay_t<Function>>::value
 	context& function(std::string_view name, Function&& func)
+	{
+		return value(name, wrap_function<Function, Traits>(isolate_, name, std::forward<Function>(func)));
+	}
+
+	/// Set a Fast API function to the context global object
+	template<auto FuncPtr, typename Traits = raw_ptr_traits>
+	context& function(std::string_view name, fast_function<FuncPtr>)
+	{
+		return value(name, wrap_function<FuncPtr, Traits>(isolate_, name, fast_function<FuncPtr>{}));
+	}
+
+	/// Set functions with default parameter values to the context global object
+	template<typename Function, typename... Defs, typename Traits = raw_ptr_traits>
+	context& function(std::string_view name, Function&& func, v8pp::defaults<Defs...> defs)
 	{
 		using Fun = typename std::decay_t<Function>;
 		static_assert(detail::is_callable<Fun>::value, "Function must be callable");
-		return value(name, wrap_function<Function, Traits>(isolate_, name, std::forward<Function>(func)));
+		return value(name, wrap_function<Function, Traits>(isolate_, name,
+			std::forward<Function>(func), std::move(defs)));
+	}
+
+	/// Set multiple overloaded functions to the context global object
+	template<typename F1, typename F2, typename... Fs, typename Traits = raw_ptr_traits>
+		requires (detail::is_callable<std::decay_t<F2>>::value
+			|| std::is_member_function_pointer_v<std::decay_t<F2>>
+			|| is_overload_entry<std::decay_t<F2>>::value)
+	context& function(std::string_view name, F1&& f1, F2&& f2, Fs&&... fs)
+	{
+		return value(name, wrap_overload(isolate_, name,
+			std::forward<F1>(f1), std::forward<F2>(f2), std::forward<Fs>(fs)...));
 	}
 
 	/// Set class to the context global object

--- a/v8pp/context_store.cpp
+++ b/v8pp/context_store.cpp
@@ -1,0 +1,5 @@
+#include "v8pp/config.hpp"
+
+#if !V8PP_HEADER_ONLY
+#include "v8pp/context_store.ipp"
+#endif

--- a/v8pp/context_store.hpp
+++ b/v8pp/context_store.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <v8.h>
+
+#include "v8pp/config.hpp"
+#include "v8pp/convert.hpp"
+#include "v8pp/object.hpp"
+
+namespace v8pp {
+
+/// A key-value store backed by a dedicated V8 context.
+///
+/// Designed to hold named V8 values that outlive ephemeral contexts
+/// on the same isolate. Values are stored as live V8 object references
+/// (no serialization), so wrapped C++ objects, functions, and complex
+/// JS structures survive intact.
+///
+/// The store creates and owns a lightweight V8 context internally.
+/// All stored values live in a dedicated storage object (not the global).
+///
+/// Thread safety: same as V8 — single-threaded per isolate.
+///
+/// Usage:
+///   v8::Isolate* isolate = ...;
+///   v8pp::context_store store(isolate);
+///
+///   // Save values before destroying a context
+///   store.save_from(old_ctx->impl(), {"state", "config"});
+///
+///   // ... destroy and recreate context ...
+///
+///   // Restore values into the new context
+///   store.restore_to(new_ctx->impl(), {"state", "config"});
+class context_store
+{
+public:
+	/// Create a store on the given isolate.
+	/// The isolate must outlive this store.
+	explicit context_store(v8::Isolate* isolate);
+
+	~context_store();
+
+	context_store(context_store const&) = delete;
+	context_store& operator=(context_store const&) = delete;
+
+	context_store(context_store&&) noexcept;
+	context_store& operator=(context_store&&) noexcept;
+
+	/// The isolate this store belongs to
+	v8::Isolate* isolate() const { return isolate_; }
+
+	/// The internal V8 context (for advanced use)
+	v8::Local<v8::Context> impl() const { return to_local(isolate_, store_ctx_); }
+
+	/// Store a value under the given name.
+	/// Dot-separated names create/traverse subobjects.
+	/// Overwrites existing values. Returns true on success.
+	bool set(std::string_view name, v8::Local<v8::Value> value);
+
+	/// Store a C++ value (converted via convert<T>).
+	template<typename T>
+	bool set(std::string_view name, T const& value)
+	{
+		v8::HandleScope scope(isolate_);
+		v8::Local<v8::Value> v8_value = to_v8(isolate_, value);
+		return set(name, v8_value);
+	}
+
+	/// Retrieve a value by name.
+	/// Returns true if the name exists and value is not undefined.
+	/// The returned handle is valid in the caller's HandleScope.
+	bool get(std::string_view name, v8::Local<v8::Value>& out) const;
+
+	/// Retrieve and convert a value to C++ type T.
+	template<typename T>
+	bool get(std::string_view name, T& out) const
+	{
+		v8::HandleScope scope(isolate_);
+		v8::Local<v8::Value> val;
+		if (!get(name, val))
+		{
+			return false;
+		}
+		out = from_v8<T>(isolate_, val);
+		return true;
+	}
+
+	/// Check whether a name exists in the store.
+	bool has(std::string_view name) const;
+
+	/// Remove a value from the store. Returns true if it existed.
+	bool remove(std::string_view name);
+
+	/// Remove all stored values.
+	void clear();
+
+	/// Number of top-level stored values.
+	size_t size() const;
+
+	/// Names of all top-level stored values.
+	std::vector<std::string> keys() const;
+
+	/// Save named values from a source context into this store.
+	/// Returns the number of values successfully saved.
+	size_t save_from(v8::Local<v8::Context> source,
+		std::initializer_list<std::string_view> names);
+
+	/// Restore named values from this store into a target context.
+	/// Returns the number of values successfully restored.
+	size_t restore_to(v8::Local<v8::Context> target,
+		std::initializer_list<std::string_view> names) const;
+
+	/// Store a JSON-serialized deep copy of a value.
+	/// Returns false if serialization fails (e.g., circular references).
+	bool set_json(std::string_view name, v8::Local<v8::Value> value);
+
+	/// Retrieve a deep copy via JSON into the caller's context.
+	/// Returns false if the name doesn't exist or parsing fails.
+	bool get_json(std::string_view name, v8::Local<v8::Value>& out) const;
+
+private:
+	v8::Isolate* isolate_;
+	v8::Global<v8::Context> store_ctx_;
+	v8::Global<v8::Object> store_obj_;
+
+	/// Like traverse_subobjects but creates missing intermediate objects.
+	static bool ensure_subobjects(v8::Isolate* isolate, v8::Local<v8::Context> context,
+		v8::Local<v8::Object>& obj, std::string_view& name);
+};
+
+} // namespace v8pp
+
+#if V8PP_HEADER_ONLY
+#include "v8pp/context_store.ipp"
+#endif

--- a/v8pp/context_store.ipp
+++ b/v8pp/context_store.ipp
@@ -1,0 +1,338 @@
+#include "v8pp/context_store.hpp"
+#include "v8pp/json.hpp"
+
+namespace v8pp {
+
+V8PP_IMPL context_store::context_store(v8::Isolate* isolate)
+	: isolate_(isolate)
+{
+	v8::HandleScope scope(isolate_);
+	v8::Local<v8::Context> ctx = v8::Context::New(isolate_);
+	store_ctx_.Reset(isolate_, ctx);
+
+	v8::Context::Scope context_scope(ctx);
+	v8::Local<v8::Object> obj = v8::Object::New(isolate_);
+	store_obj_.Reset(isolate_, obj);
+}
+
+V8PP_IMPL context_store::~context_store()
+{
+	store_obj_.Reset();
+	store_ctx_.Reset();
+	isolate_ = nullptr;
+}
+
+V8PP_IMPL context_store::context_store(context_store&& src) noexcept
+	: isolate_(std::exchange(src.isolate_, nullptr))
+	, store_ctx_(std::move(src.store_ctx_))
+	, store_obj_(std::move(src.store_obj_))
+{
+}
+
+V8PP_IMPL context_store& context_store::operator=(context_store&& src) noexcept
+{
+	if (this != &src)
+	{
+		store_obj_.Reset();
+		store_ctx_.Reset();
+		isolate_ = std::exchange(src.isolate_, nullptr);
+		store_ctx_ = std::move(src.store_ctx_);
+		store_obj_ = std::move(src.store_obj_);
+	}
+	return *this;
+}
+
+V8PP_IMPL bool context_store::ensure_subobjects(v8::Isolate* isolate, v8::Local<v8::Context> context,
+	v8::Local<v8::Object>& obj, std::string_view& name)
+{
+	for (;;)
+	{
+		auto const dot = name.find('.');
+		if (dot == name.npos)
+		{
+			return true;
+		}
+
+		auto const segment = name.substr(0, dot);
+		v8::Local<v8::String> key = v8pp::to_v8(isolate, segment);
+		v8::Local<v8::Value> part;
+		if (obj->Get(context, key).ToLocal(&part) && part->IsObject())
+		{
+			obj = part.As<v8::Object>();
+		}
+		else
+		{
+			v8::Local<v8::Object> new_obj = v8::Object::New(isolate);
+			if (!obj->Set(context, key, new_obj).FromMaybe(false))
+			{
+				return false;
+			}
+			obj = new_obj;
+		}
+		name.remove_prefix(dot + 1);
+	}
+}
+
+V8PP_IMPL bool context_store::set(std::string_view name, v8::Local<v8::Value> value)
+{
+	v8::HandleScope scope(isolate_);
+	v8::Local<v8::Context> ctx = impl();
+	v8::Context::Scope context_scope(ctx);
+
+	v8::Local<v8::Object> obj = to_local(isolate_, store_obj_);
+	if (!ensure_subobjects(isolate_, ctx, obj, name))
+	{
+		return false;
+	}
+	return obj->Set(ctx, v8pp::to_v8(isolate_, name), value).FromMaybe(false);
+}
+
+V8PP_IMPL bool context_store::get(std::string_view name, v8::Local<v8::Value>& out) const
+{
+	v8::EscapableHandleScope scope(isolate_);
+	v8::Local<v8::Context> ctx = impl();
+	v8::Context::Scope context_scope(ctx);
+
+	v8::Local<v8::Object> obj = to_local(isolate_, store_obj_);
+	if (!traverse_subobjects(isolate_, ctx, obj, name))
+	{
+		return false;
+	}
+
+	v8::Local<v8::Value> val;
+	if (!obj->Get(ctx, v8pp::to_v8(isolate_, name)).ToLocal(&val) || val->IsUndefined())
+	{
+		return false;
+	}
+	out = scope.Escape(val);
+	return true;
+}
+
+V8PP_IMPL bool context_store::has(std::string_view name) const
+{
+	v8::HandleScope scope(isolate_);
+	v8::Local<v8::Context> ctx = impl();
+	v8::Context::Scope context_scope(ctx);
+
+	v8::Local<v8::Object> obj = to_local(isolate_, store_obj_);
+	if (!traverse_subobjects(isolate_, ctx, obj, name))
+	{
+		return false;
+	}
+
+	v8::Local<v8::Value> val;
+	if (!obj->Get(ctx, v8pp::to_v8(isolate_, name)).ToLocal(&val) || val->IsUndefined())
+	{
+		return false;
+	}
+	return true;
+}
+
+V8PP_IMPL bool context_store::remove(std::string_view name)
+{
+	v8::HandleScope scope(isolate_);
+	v8::Local<v8::Context> ctx = impl();
+	v8::Context::Scope context_scope(ctx);
+
+	v8::Local<v8::Object> obj = to_local(isolate_, store_obj_);
+	if (!traverse_subobjects(isolate_, ctx, obj, name))
+	{
+		return false;
+	}
+
+	v8::Local<v8::String> key = v8pp::to_v8(isolate_, name);
+	if (!obj->Has(ctx, key).FromMaybe(false))
+	{
+		return false;
+	}
+	return obj->Delete(ctx, key).FromMaybe(false);
+}
+
+V8PP_IMPL void context_store::clear()
+{
+	v8::HandleScope scope(isolate_);
+	v8::Local<v8::Context> ctx = impl();
+	v8::Context::Scope context_scope(ctx);
+
+	v8::Local<v8::Object> obj = v8::Object::New(isolate_);
+	store_obj_.Reset(isolate_, obj);
+}
+
+V8PP_IMPL size_t context_store::size() const
+{
+	v8::HandleScope scope(isolate_);
+	v8::Local<v8::Context> ctx = impl();
+	v8::Context::Scope context_scope(ctx);
+
+	v8::Local<v8::Array> names;
+	if (!to_local(isolate_, store_obj_)->GetOwnPropertyNames(ctx).ToLocal(&names))
+	{
+		return 0;
+	}
+	return names->Length();
+}
+
+V8PP_IMPL std::vector<std::string> context_store::keys() const
+{
+	v8::HandleScope scope(isolate_);
+	v8::Local<v8::Context> ctx = impl();
+	v8::Context::Scope context_scope(ctx);
+
+	std::vector<std::string> result;
+	v8::Local<v8::Array> names;
+	if (!to_local(isolate_, store_obj_)->GetOwnPropertyNames(ctx).ToLocal(&names))
+	{
+		return result;
+	}
+
+	result.reserve(names->Length());
+	for (uint32_t i = 0; i < names->Length(); ++i)
+	{
+		v8::Local<v8::Value> key;
+		if (names->Get(ctx, i).ToLocal(&key))
+		{
+			result.push_back(from_v8<std::string>(isolate_, key));
+		}
+	}
+	return result;
+}
+
+V8PP_IMPL size_t context_store::save_from(v8::Local<v8::Context> source,
+	std::initializer_list<std::string_view> names)
+{
+	v8::HandleScope scope(isolate_);
+	size_t count = 0;
+
+	for (auto const full_name : names)
+	{
+		v8::Local<v8::Value> val;
+
+		// Read value from source context
+		{
+			v8::Context::Scope source_scope(source);
+			v8::Local<v8::Object> src_global = source->Global();
+			std::string_view leaf = full_name;
+
+			if (!traverse_subobjects(isolate_, source, src_global, leaf))
+			{
+				continue;
+			}
+			if (!src_global->Get(source, v8pp::to_v8(isolate_, leaf)).ToLocal(&val)
+				|| val->IsUndefined())
+			{
+				continue;
+			}
+		}
+
+		// Store under the original full name
+		if (set(full_name, val))
+		{
+			++count;
+		}
+	}
+	return count;
+}
+
+V8PP_IMPL size_t context_store::restore_to(v8::Local<v8::Context> target,
+	std::initializer_list<std::string_view> names) const
+{
+	v8::HandleScope scope(isolate_);
+	size_t count = 0;
+
+	for (auto name : names)
+	{
+		v8::Local<v8::Value> val;
+		if (!get(name, val))
+		{
+			continue;
+		}
+
+		// Write value into target context
+		{
+			v8::Context::Scope target_scope(target);
+			v8::Local<v8::Object> tgt_global = target->Global();
+			std::string_view leaf = name;
+
+			if (!ensure_subobjects(isolate_, target, tgt_global, leaf))
+			{
+				continue;
+			}
+			if (tgt_global->Set(target, v8pp::to_v8(isolate_, leaf), val).FromMaybe(false))
+			{
+				++count;
+			}
+		}
+	}
+	return count;
+}
+
+V8PP_IMPL bool context_store::set_json(std::string_view name, v8::Local<v8::Value> value)
+{
+	v8::HandleScope scope(isolate_);
+
+	// Stringify in the caller's current context
+	std::string json = json_str(isolate_, value);
+	if (json.empty())
+	{
+		return false;
+	}
+
+	// Parse and store in the store's context
+	v8::Local<v8::Context> ctx = impl();
+	v8::Context::Scope context_scope(ctx);
+
+	v8::Local<v8::Value> parsed = json_parse(isolate_, json);
+	if (parsed.IsEmpty() || parsed->IsUndefined())
+	{
+		return false;
+	}
+
+	v8::Local<v8::Object> obj = to_local(isolate_, store_obj_);
+	if (!ensure_subobjects(isolate_, ctx, obj, name))
+	{
+		return false;
+	}
+	return obj->Set(ctx, v8pp::to_v8(isolate_, name), parsed).FromMaybe(false);
+}
+
+V8PP_IMPL bool context_store::get_json(std::string_view name, v8::Local<v8::Value>& out) const
+{
+	v8::EscapableHandleScope scope(isolate_);
+
+	// Read and stringify in the store's context
+	std::string json;
+	{
+		v8::HandleScope inner_scope(isolate_);
+		v8::Local<v8::Context> ctx = impl();
+		v8::Context::Scope context_scope(ctx);
+
+		v8::Local<v8::Object> obj = to_local(isolate_, store_obj_);
+		if (!traverse_subobjects(isolate_, ctx, obj, name))
+		{
+			return false;
+		}
+
+		v8::Local<v8::Value> val;
+		if (!obj->Get(ctx, v8pp::to_v8(isolate_, name)).ToLocal(&val) || val->IsUndefined())
+		{
+			return false;
+		}
+		json = json_str(isolate_, val);
+	}
+
+	if (json.empty())
+	{
+		return false;
+	}
+
+	// Parse in the caller's current context
+	v8::Local<v8::Value> parsed = json_parse(isolate_, json);
+	if (parsed.IsEmpty() || parsed->IsUndefined())
+	{
+		return false;
+	}
+	out = scope.Escape(parsed);
+	return true;
+}
+
+} // namespace v8pp

--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -224,11 +224,7 @@ struct convert<bool>
 		{
 			throw invalid_argument(isolate, value, "Boolean");
 		}
-#if (V8_MAJOR_VERSION > 7) || (V8_MAJOR_VERSION == 7 && V8_MINOR_VERSION >= 1)
 		return value->BooleanValue(isolate);
-#else
-		return value->BooleanValue(isolate->GetCurrentContext()).FromJust();
-#endif
 	}
 
 	static to_type to_v8(v8::Isolate* isolate, bool value)

--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -82,7 +82,11 @@ struct convert<String, typename std::enable_if<detail::is_string<String>::value>
 		}
 
 		v8::HandleScope scope(isolate);
-		v8::Local<v8::String> str = value->ToString(isolate->GetCurrentContext()).ToLocalChecked();
+		v8::Local<v8::String> str;
+		if (!value->ToString(isolate->GetCurrentContext()).ToLocal(&str))
+		{
+			throw invalid_argument(isolate, value, "String");
+		}
 
 #if V8_MAJOR_VERSION > 13 || (V8_MAJOR_VERSION == 13 && V8_MINOR_VERSION >= 3)
 		if constexpr (sizeof(Char) == 1)
@@ -727,7 +731,11 @@ struct convert<Mapping, typename std::enable_if<detail::is_mapping<Mapping>::val
 		v8::HandleScope scope(isolate);
 		v8::Local<v8::Context> context = isolate->GetCurrentContext();
 		v8::Local<v8::Object> object = value.As<v8::Object>();
-		v8::Local<v8::Array> prop_names = object->GetPropertyNames(context).ToLocalChecked();
+		v8::Local<v8::Array> prop_names;
+		if (!object->GetPropertyNames(context).ToLocal(&prop_names))
+		{
+			throw invalid_argument(isolate, value, "Object");
+		}
 
 		from_type result{};
 		for (uint32_t i = 0, count = prop_names->Length(); i < count; ++i)

--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -1098,11 +1098,10 @@ inline v8::Local<v8::String> to_v8(v8::Isolate* isolate, char const* str, size_t
 	return convert<std::string_view>::to_v8(isolate, std::string_view(str, len));
 }
 
-template<size_t N>
-v8::Local<v8::String> to_v8(v8::Isolate* isolate,
-	char const (&str)[N], size_t len = N - 1)
+template<int N>
+v8::Local<v8::String> to_v8(v8::Isolate* isolate, char const (&str)[N])
 {
-	return convert<std::string_view>::to_v8(isolate, std::string_view(str, len));
+	return v8::String::NewFromUtf8Literal(isolate, str);
 }
 
 inline v8::Local<v8::String> to_v8(v8::Isolate* isolate, char16_t const* str)
@@ -1140,6 +1139,13 @@ v8::Local<v8::String> to_v8(v8::Isolate* isolate,
 	return convert<std::wstring_view>::to_v8(isolate, std::wstring_view(str, len));
 }
 #endif
+
+/// Create an internalized V8 string, optimized for property/method names
+inline v8::Local<v8::String> to_v8_name(v8::Isolate* isolate, std::string_view name)
+{
+	return v8::String::NewFromUtf8(isolate, name.data(),
+		v8::NewStringType::kInternalized, static_cast<int>(name.size())).ToLocalChecked();
+}
 
 template<typename T>
 v8::Local<v8::Value> to_v8(v8::Isolate* isolate, std::optional<T> const& value)

--- a/v8pp/fast_api.hpp
+++ b/v8pp/fast_api.hpp
@@ -79,7 +79,11 @@ struct fast_callback<MemPtr>
 		void* ptr = receiver->GetAlignedPointerFromInternalField(0);
 		if (!ptr)
 		{
+#if V8_MAJOR_VERSION > 12 || (V8_MAJOR_VERSION == 12 && V8_MINOR_VERSION >= 9)
+			options.isolate->ThrowError("Invalid receiver: null C++ object");
+#else
 			options.fallback = true;
+#endif
 			if constexpr (std::is_void_v<R>) return;
 			else return R{};
 		}
@@ -97,7 +101,11 @@ struct fast_callback<MemPtr>
 		void* ptr = receiver->GetAlignedPointerFromInternalField(0);
 		if (!ptr)
 		{
+#if V8_MAJOR_VERSION > 12 || (V8_MAJOR_VERSION == 12 && V8_MINOR_VERSION >= 9)
+			options.isolate->ThrowError("Invalid receiver: null C++ object");
+#else
 			options.fallback = true;
+#endif
 			if constexpr (std::is_void_v<R>) return;
 			else return R{};
 		}

--- a/v8pp/fast_api.hpp
+++ b/v8pp/fast_api.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <type_traits>
+
+#include <v8.h>
+
+#if V8_MAJOR_VERSION >= 10
+#include <v8-fast-api-calls.h>
+#endif
+
+namespace v8pp {
+
+namespace detail {
+
+/// Check if T is a supported Fast API return type
+/// V8 10.x supports: void, bool, int32_t, uint32_t, float, double
+template<typename T>
+constexpr bool is_fast_return_type_v =
+	std::is_void_v<T> ||
+	std::is_same_v<T, bool> ||
+	std::is_same_v<T, int32_t> ||
+	std::is_same_v<T, uint32_t> ||
+	std::is_same_v<T, float> ||
+	std::is_same_v<T, double>;
+
+/// Check if T is a supported Fast API argument type
+/// V8 10.x supports: bool, int32_t, uint32_t, int64_t, uint64_t, float, double
+template<typename T>
+constexpr bool is_fast_arg_type_v =
+	std::is_same_v<T, bool> ||
+	std::is_same_v<T, int32_t> ||
+	std::is_same_v<T, uint32_t> ||
+	std::is_same_v<T, int64_t> ||
+	std::is_same_v<T, uint64_t> ||
+	std::is_same_v<T, float> ||
+	std::is_same_v<T, double>;
+
+/// Check if a function signature is Fast API compatible
+template<typename F>
+struct is_fast_api_compatible : std::false_type {};
+
+template<typename R, typename... Args>
+struct is_fast_api_compatible<R(*)(Args...)>
+	: std::bool_constant<is_fast_return_type_v<R> && (is_fast_arg_type_v<Args> && ...)> {};
+
+template<typename R, typename C, typename... Args>
+struct is_fast_api_compatible<R(C::*)(Args...)>
+	: std::bool_constant<is_fast_return_type_v<R> && (is_fast_arg_type_v<Args> && ...)> {};
+
+template<typename R, typename C, typename... Args>
+struct is_fast_api_compatible<R(C::*)(Args...) const>
+	: std::bool_constant<is_fast_return_type_v<R> && (is_fast_arg_type_v<Args> && ...)> {};
+
+#if V8_MAJOR_VERSION >= 10
+
+/// Fast callback wrapper — generates a static function with the V8 fast API signature.
+/// Uses NTTP to bake the function pointer at compile time so V8 can call it directly.
+template<auto FuncPtr>
+struct fast_callback;
+
+/// Free function: R(*)(Args...)
+template<typename R, typename... Args, R(*FuncPtr)(Args...)>
+struct fast_callback<FuncPtr>
+{
+	static R call(v8::Local<v8::Object> receiver, Args... args,
+		v8::FastApiCallbackOptions& options)
+	{
+		return FuncPtr(args...);
+	}
+};
+
+/// Member function: R(C::*)(Args...) — extracts C++ object from receiver internal field 0
+template<typename R, typename C, typename... Args, R(C::*MemPtr)(Args...)>
+struct fast_callback<MemPtr>
+{
+	static R call(v8::Local<v8::Object> receiver, Args... args,
+		v8::FastApiCallbackOptions& options)
+	{
+		void* ptr = receiver->GetAlignedPointerFromInternalField(0);
+		if (!ptr)
+		{
+			options.fallback = true;
+			if constexpr (std::is_void_v<R>) return;
+			else return R{};
+		}
+		return (static_cast<C*>(ptr)->*MemPtr)(args...);
+	}
+};
+
+/// Const member function: R(C::*)(Args...) const
+template<typename R, typename C, typename... Args, R(C::*MemPtr)(Args...) const>
+struct fast_callback<MemPtr>
+{
+	static R call(v8::Local<v8::Object> receiver, Args... args,
+		v8::FastApiCallbackOptions& options)
+	{
+		void* ptr = receiver->GetAlignedPointerFromInternalField(0);
+		if (!ptr)
+		{
+			options.fallback = true;
+			if constexpr (std::is_void_v<R>) return;
+			else return R{};
+		}
+		return (static_cast<C const*>(ptr)->*MemPtr)(args...);
+	}
+};
+
+#endif // V8_MAJOR_VERSION >= 10
+
+} // namespace detail
+
+/// Tag to detect fast_function types
+template<typename T>
+struct is_fast_function : std::false_type {};
+
+/// Compile-time Fast API function wrapper.
+/// Wraps a function pointer as a non-type template parameter to enable V8 Fast API callbacks.
+/// Compatible signatures get both a fast callback (called directly by V8's JIT) and
+/// the standard slow callback. Incompatible signatures silently fall back to slow-only.
+/// Usage: module.function("add", v8pp::fast_fn<&add>);
+template<auto FuncPtr>
+struct fast_function
+{
+	using func_type = decltype(FuncPtr);
+	static constexpr func_type ptr = FuncPtr;
+	static constexpr bool compatible = detail::is_fast_api_compatible<func_type>::value;
+};
+
+template<auto FuncPtr>
+struct is_fast_function<fast_function<FuncPtr>> : std::true_type {};
+
+/// Variable template for convenient use
+template<auto FuncPtr>
+inline constexpr fast_function<FuncPtr> fast_fn{};
+
+} // namespace v8pp

--- a/v8pp/function.hpp
+++ b/v8pp/function.hpp
@@ -336,7 +336,7 @@ v8::Local<v8::FunctionTemplate> wrap_function_template(v8::Isolate* isolate,
 	v8::SideEffectType side_effect_type = v8::SideEffectType::kHasSideEffect)
 {
 	using F_type = typename fast_function<FuncPtr>::func_type;
-#if V8_MAJOR_VERSION >= 10
+#ifdef V8PP_HAS_FAST_API_HEADER
 	if constexpr (fast_function<FuncPtr>::compatible)
 	{
 		auto c_func = v8::CFunction::Make(&detail::fast_callback<FuncPtr>::call);

--- a/v8pp/function.hpp
+++ b/v8pp/function.hpp
@@ -199,9 +199,13 @@ template<typename F, typename Traits = raw_ptr_traits>
 v8::Local<v8::Function> wrap_function(v8::Isolate* isolate, std::string_view name, F&& func)
 {
 	using F_type = typename std::decay_t<F>;
-	v8::Local<v8::Function> fn = v8::Function::New(isolate->GetCurrentContext(),
+	v8::Local<v8::Function> fn;
+	if (!v8::Function::New(isolate->GetCurrentContext(),
 		&detail::forward_function<Traits, F_type>,
-		detail::external_data::set(isolate, std::forward<F_type>(func))).ToLocalChecked();
+		detail::external_data::set(isolate, std::forward<F_type>(func))).ToLocal(&fn))
+	{
+		return {};
+	}
 	if (!name.empty())
 	{
 		fn->SetName(to_v8(isolate, name));

--- a/v8pp/function.hpp
+++ b/v8pp/function.hpp
@@ -5,6 +5,7 @@
 #include <type_traits>
 
 #include "v8pp/call_from_v8.hpp"
+#include "v8pp/fast_api.hpp"
 #include "v8pp/ptr_traits.hpp"
 #include "v8pp/throw_ex.hpp"
 #include "v8pp/utility.hpp"
@@ -131,6 +132,14 @@ private:
 	};
 };
 
+/// Bundles a callable F with its default parameter values
+template<typename F, typename Defaults>
+struct function_with_defaults
+{
+	F func;
+	Defaults defs;
+};
+
 template<typename Traits, typename F, typename FTraits>
 decltype(auto) invoke(v8::FunctionCallbackInfo<v8::Value> const& args)
 {
@@ -178,6 +187,62 @@ void forward_function(v8::FunctionCallbackInfo<v8::Value> const& args)
 	}
 }
 
+/// V8 callback adapter for functions with default parameter values
+template<typename Traits, typename F, typename Defaults>
+void forward_function_with_defaults(v8::FunctionCallbackInfo<v8::Value> const& args)
+{
+	using FTraits = function_traits<F>;
+	using Bundle = function_with_defaults<F, Defaults>;
+
+	static_assert(is_callable<F>::value || std::is_member_function_pointer_v<F>, "required callable F");
+
+	v8::Isolate* isolate = args.GetIsolate();
+	v8::HandleScope scope(isolate);
+	try
+	{
+		auto& bundle = external_data::get<Bundle>(args.Data());
+
+		if constexpr (std::is_member_function_pointer<F>())
+		{
+			using class_type = std::decay_t<typename FTraits::class_type>;
+			auto obj = class_<class_type, Traits>::unwrap_object(isolate, args.This());
+			if (!obj)
+			{
+				throw std::runtime_error("method called on null instance");
+			}
+			if constexpr (std::same_as<typename FTraits::return_type, void>)
+			{
+				call_from_v8<Traits>(std::forward<F>(bundle.func), args, bundle.defs, *obj);
+			}
+			else
+			{
+				using return_type = typename FTraits::return_type;
+				using converter = typename call_from_v8_traits<F>::template arg_converter<return_type, Traits>;
+				args.GetReturnValue().Set(converter::to_v8(isolate,
+					call_from_v8<Traits>(std::forward<F>(bundle.func), args, bundle.defs, *obj)));
+			}
+		}
+		else
+		{
+			if constexpr (std::same_as<typename FTraits::return_type, void>)
+			{
+				call_from_v8<Traits>(std::forward<F>(bundle.func), args, bundle.defs);
+			}
+			else
+			{
+				using return_type = typename FTraits::return_type;
+				using converter = typename call_from_v8_traits<F>::template arg_converter<return_type, Traits>;
+				args.GetReturnValue().Set(converter::to_v8(isolate,
+					call_from_v8<Traits>(std::forward<F>(bundle.func), args, bundle.defs)));
+			}
+		}
+	}
+	catch (std::exception const& ex)
+	{
+		args.GetReturnValue().Set(throw_ex(isolate, ex.what()));
+	}
+}
+
 } // namespace v8pp::detail
 
 namespace v8pp {
@@ -196,6 +261,48 @@ v8::Local<v8::FunctionTemplate> wrap_function_template(v8::Isolate* isolate, F&&
 		side_effect_type);
 }
 
+/// Wrap C++ function with default parameter values into new V8 function template
+template<typename F, typename Traits = raw_ptr_traits, typename... Defs>
+v8::Local<v8::FunctionTemplate> wrap_function_template(v8::Isolate* isolate, F&& func,
+	v8pp::defaults<Defs...> defs,
+	v8::SideEffectType side_effect_type = v8::SideEffectType::kHasSideEffect)
+{
+	using F_type = typename std::decay_t<F>;
+	using Defaults = v8pp::defaults<Defs...>;
+	using Bundle = detail::function_with_defaults<F_type, Defaults>;
+	return v8::FunctionTemplate::New(isolate,
+		&detail::forward_function_with_defaults<Traits, F_type, Defaults>,
+		detail::external_data::set(isolate, Bundle{std::forward<F_type>(func), std::move(defs)}),
+		v8::Local<v8::Signature>(), 0,
+		v8::ConstructorBehavior::kAllow,
+		side_effect_type);
+}
+
+/// Wrap C++ function with default parameter values into new V8 function
+template<typename F, typename Traits = raw_ptr_traits, typename... Defs>
+v8::Local<v8::Function> wrap_function(v8::Isolate* isolate, std::string_view name, F&& func,
+	v8pp::defaults<Defs...> defs,
+	v8::SideEffectType side_effect_type = v8::SideEffectType::kHasSideEffect)
+{
+	using F_type = typename std::decay_t<F>;
+	using Defaults = v8pp::defaults<Defs...>;
+	using Bundle = detail::function_with_defaults<F_type, Defaults>;
+	v8::Local<v8::Function> fn;
+	if (!v8::Function::New(isolate->GetCurrentContext(),
+		&detail::forward_function_with_defaults<Traits, F_type, Defaults>,
+		detail::external_data::set(isolate, Bundle{std::forward<F_type>(func), std::move(defs)}),
+		0, v8::ConstructorBehavior::kAllow,
+		side_effect_type).ToLocal(&fn))
+	{
+		return {};
+	}
+	if (!name.empty())
+	{
+		fn->SetName(to_v8_name(isolate, name));
+	}
+	return fn;
+}
+
 /// Wrap C++ function into new V8 function
 /// Set nullptr or empty string for name
 /// to make the function anonymous
@@ -210,6 +317,59 @@ v8::Local<v8::Function> wrap_function(v8::Isolate* isolate, std::string_view nam
 		detail::external_data::set(isolate, std::forward<F_type>(func)),
 		0, v8::ConstructorBehavior::kAllow,
 		side_effect_type).ToLocal(&fn))
+	{
+		return {};
+	}
+	if (!name.empty())
+	{
+		fn->SetName(to_v8_name(isolate, name));
+	}
+	return fn;
+}
+
+/// Wrap a fast_function into a V8 function template with optional Fast API callback.
+/// Compatible signatures get a CFunction for the V8 JIT fast path.
+/// Incompatible signatures or V8 < 10 silently fall back to slow-only.
+template<auto FuncPtr, typename Traits = raw_ptr_traits>
+v8::Local<v8::FunctionTemplate> wrap_function_template(v8::Isolate* isolate,
+	fast_function<FuncPtr>,
+	v8::SideEffectType side_effect_type = v8::SideEffectType::kHasSideEffect)
+{
+	using F_type = typename fast_function<FuncPtr>::func_type;
+#if V8_MAJOR_VERSION >= 10
+	if constexpr (fast_function<FuncPtr>::compatible)
+	{
+		auto c_func = v8::CFunction::Make(&detail::fast_callback<FuncPtr>::call);
+		return v8::FunctionTemplate::New(isolate,
+			&detail::forward_function<Traits, F_type>,
+			detail::external_data::set(isolate, FuncPtr),
+			v8::Local<v8::Signature>(), 0,
+			v8::ConstructorBehavior::kThrow,
+			side_effect_type,
+			&c_func);
+	}
+	else
+#endif
+	{
+		return v8::FunctionTemplate::New(isolate,
+			&detail::forward_function<Traits, F_type>,
+			detail::external_data::set(isolate, FuncPtr),
+			v8::Local<v8::Signature>(), 0,
+			v8::ConstructorBehavior::kAllow,
+			side_effect_type);
+	}
+}
+
+/// Wrap a fast_function into a V8 function (for context global bindings)
+template<auto FuncPtr, typename Traits = raw_ptr_traits>
+v8::Local<v8::Function> wrap_function(v8::Isolate* isolate, std::string_view name,
+	fast_function<FuncPtr>,
+	v8::SideEffectType side_effect_type = v8::SideEffectType::kHasSideEffect)
+{
+	auto tmpl = wrap_function_template<FuncPtr, Traits>(isolate,
+		fast_function<FuncPtr>{}, side_effect_type);
+	v8::Local<v8::Function> fn;
+	if (!tmpl->GetFunction(isolate->GetCurrentContext()).ToLocal(&fn))
 	{
 		return {};
 	}

--- a/v8pp/module.hpp
+++ b/v8pp/module.hpp
@@ -117,10 +117,17 @@ public:
 		v8::AccessorNameGetterCallback getter = &var_get<Variable>;
 		v8::AccessorNameSetterCallback setter = &var_set<Variable>;
 		v8::Local<v8::Value> data = detail::external_data::set(isolate_, &var);
+#if V8_MAJOR_VERSION > 12 || (V8_MAJOR_VERSION == 12 && V8_MINOR_VERSION >= 9)
+		obj_->SetNativeDataProperty(v8_name, getter, setter, data,
+			v8::PropertyAttribute::DontDelete,
+			v8::SideEffectType::kHasNoSideEffect,
+			v8::SideEffectType::kHasSideEffectToReceiver);
+#else
 		obj_->SetNativeDataProperty(v8_name, getter, setter, data,
 			v8::PropertyAttribute::DontDelete, v8::DEFAULT,
 			v8::SideEffectType::kHasNoSideEffect,
 			v8::SideEffectType::kHasSideEffectToReceiver);
+#endif
 		return *this;
 	}
 
@@ -148,9 +155,15 @@ public:
 		v8::SideEffectType setter_effect = property_type::is_readonly
 			? v8::SideEffectType::kHasSideEffect
 			: v8::SideEffectType::kHasSideEffectToReceiver;
+#if V8_MAJOR_VERSION > 12 || (V8_MAJOR_VERSION == 12 && V8_MINOR_VERSION >= 9)
+		obj_->SetNativeDataProperty(v8_name, getter, setter, data,
+			v8::PropertyAttribute::DontDelete,
+			v8::SideEffectType::kHasNoSideEffect, setter_effect);
+#else
 		obj_->SetNativeDataProperty(v8_name, getter, setter, data,
 			v8::PropertyAttribute::DontDelete, v8::DEFAULT,
 			v8::SideEffectType::kHasNoSideEffect, setter_effect);
+#endif
 		return *this;
 	}
 

--- a/v8pp/overload.hpp
+++ b/v8pp/overload.hpp
@@ -1,0 +1,337 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#include "v8pp/call_from_v8.hpp"
+#include "v8pp/function.hpp"
+
+namespace v8pp {
+
+/// Compile-time overload selector for free functions
+template<typename Sig>
+constexpr auto overload(Sig* f) -> Sig* { return f; }
+
+/// Compile-time overload selector for member function pointers
+template<typename MemFn>
+	requires std::is_member_function_pointer_v<MemFn>
+constexpr MemFn overload(MemFn f) { return f; }
+
+/// Tag to detect overload_entry types
+template<typename T>
+struct is_overload_entry : std::false_type {};
+
+/// An overload entry bundling one function, optionally with defaults
+template<typename F, typename Defaults = void>
+struct overload_entry
+{
+	F func;
+};
+
+template<typename F, typename... Defs>
+struct overload_entry<F, defaults<Defs...>>
+{
+	F func;
+	defaults<Defs...> defs;
+};
+
+template<typename F, typename D>
+struct is_overload_entry<overload_entry<F, D>> : std::true_type {};
+
+/// Helper: wrap a function with defaults into an overload_entry
+template<typename F, typename... Defs>
+auto with_defaults(F&& func, defaults<Defs...> defs)
+{
+	using F_type = std::decay_t<F>;
+	return overload_entry<F_type, defaults<Defs...>>{std::forward<F>(func), std::move(defs)};
+}
+
+} // namespace v8pp
+
+namespace v8pp::detail {
+
+/// Compute min/max JS arg counts for one overload entry
+template<typename Entry>
+struct overload_arg_range;
+
+template<typename F>
+struct overload_arg_range<overload_entry<F, void>>
+{
+	static constexpr size_t offset = is_first_arg_isolate<F> ? 1 : 0;
+	using traits = call_from_v8_traits<F, offset>;
+	static constexpr size_t max_args = traits::arg_count;
+	static constexpr size_t min_args = max_args - traits::optional_arg_count;
+};
+
+template<typename F, typename... Defs>
+struct overload_arg_range<overload_entry<F, defaults<Defs...>>>
+{
+	static constexpr size_t offset = is_first_arg_isolate<F> ? 1 : 0;
+	using traits = call_from_v8_traits<F, offset>;
+	static constexpr size_t max_args = traits::arg_count;
+	static constexpr size_t num_defaults = sizeof...(Defs);
+	static constexpr size_t min_args = max_args - num_defaults - traits::optional_arg_count;
+};
+
+/// Check if a V8 value is valid for a given C++ arg type using convert::is_valid
+template<typename ArgType, typename Traits>
+bool arg_type_matches(v8::Isolate* isolate, v8::Local<v8::Value> value)
+{
+	using T = std::remove_cv_t<std::remove_reference_t<ArgType>>;
+	using U = std::remove_pointer_t<T>;
+	using converter = typename std::conditional_t<
+		is_wrapped_class<std::remove_cv_t<U>>::value,
+		std::conditional_t<std::is_pointer_v<T>,
+			typename Traits::template convert_ptr<U>,
+			typename Traits::template convert_ref<U>>,
+		convert<std::remove_cv_t<T>>>;
+	return converter::is_valid(isolate, value);
+}
+
+/// Check provided JS args against a function's expected types.
+/// Uses compile-time index sequence for all possible args, skips unprovided ones at runtime.
+template<typename F, typename Traits, size_t Offset, size_t... Indices>
+bool check_arg_types(v8::Isolate* isolate, v8::FunctionCallbackInfo<v8::Value> const& args,
+	size_t provided_count, std::index_sequence<Indices...>)
+{
+	using traits = call_from_v8_traits<F, Offset>;
+	// Only validate args that were actually provided by JS
+	return ((Indices >= provided_count ||
+		arg_type_matches<typename traits::template arg_type<Indices + Offset>, Traits>(
+			isolate, args[Indices])) && ...);
+}
+
+/// Check if JS args match a function's expected types (arity already validated)
+template<typename F, typename Traits>
+bool overload_types_match(v8::Isolate* isolate, v8::FunctionCallbackInfo<v8::Value> const& args,
+	size_t arg_count)
+{
+	constexpr size_t offset = is_first_arg_isolate<F> ? 1 : 0;
+	using traits = call_from_v8_traits<F, offset>;
+
+	if (arg_count == 0)
+		return true;
+
+	return check_arg_types<F, Traits, offset>(isolate, args, arg_count,
+		std::make_index_sequence<traits::arg_count>{});
+}
+
+/// Try to invoke one overload entry (no defaults). Returns true on success.
+template<typename Traits, typename F>
+bool try_invoke_entry(overload_entry<F, void> const& entry,
+	v8::FunctionCallbackInfo<v8::Value> const& args)
+{
+	using FTraits = function_traits<F>;
+	v8::Isolate* isolate = args.GetIsolate();
+	// Copy func — entry is const& so entry.func is const, but call_from_v8
+	// needs a non-const-qualified type for function_traits to work
+	F func = entry.func;
+
+	if constexpr (std::is_member_function_pointer_v<F>)
+	{
+		using class_type = std::decay_t<typename FTraits::class_type>;
+		auto obj = class_<class_type, Traits>::unwrap_object(isolate, args.This());
+		if (!obj) return false;
+
+		if constexpr (std::same_as<typename FTraits::return_type, void>)
+		{
+			call_from_v8<Traits>(std::move(func), args, *obj);
+		}
+		else
+		{
+			using return_type = typename FTraits::return_type;
+			using converter = typename call_from_v8_traits<F>::template arg_converter<return_type, Traits>;
+			args.GetReturnValue().Set(converter::to_v8(isolate,
+				call_from_v8<Traits>(std::move(func), args, *obj)));
+		}
+	}
+	else
+	{
+		if constexpr (std::same_as<typename FTraits::return_type, void>)
+		{
+			call_from_v8<Traits>(std::move(func), args);
+		}
+		else
+		{
+			using return_type = typename FTraits::return_type;
+			using converter = typename call_from_v8_traits<F>::template arg_converter<return_type, Traits>;
+			args.GetReturnValue().Set(converter::to_v8(isolate,
+				call_from_v8<Traits>(std::move(func), args)));
+		}
+	}
+	return true;
+}
+
+/// Try to invoke one overload entry (with defaults). Returns true on success.
+template<typename Traits, typename F, typename... Defs>
+bool try_invoke_entry(overload_entry<F, defaults<Defs...>> const& entry,
+	v8::FunctionCallbackInfo<v8::Value> const& args)
+{
+	using FTraits = function_traits<F>;
+	v8::Isolate* isolate = args.GetIsolate();
+	F func = entry.func;
+
+	if constexpr (std::is_member_function_pointer_v<F>)
+	{
+		using class_type = std::decay_t<typename FTraits::class_type>;
+		auto obj = class_<class_type, Traits>::unwrap_object(isolate, args.This());
+		if (!obj) return false;
+
+		if constexpr (std::same_as<typename FTraits::return_type, void>)
+		{
+			call_from_v8<Traits>(std::move(func), args, entry.defs, *obj);
+		}
+		else
+		{
+			using return_type = typename FTraits::return_type;
+			using converter = typename call_from_v8_traits<F>::template arg_converter<return_type, Traits>;
+			args.GetReturnValue().Set(converter::to_v8(isolate,
+				call_from_v8<Traits>(std::move(func), args, entry.defs, *obj)));
+		}
+	}
+	else
+	{
+		if constexpr (std::same_as<typename FTraits::return_type, void>)
+		{
+			call_from_v8<Traits>(std::move(func), args, entry.defs);
+		}
+		else
+		{
+			using return_type = typename FTraits::return_type;
+			using converter = typename call_from_v8_traits<F>::template arg_converter<return_type, Traits>;
+			args.GetReturnValue().Set(converter::to_v8(isolate,
+				call_from_v8<Traits>(std::move(func), args, entry.defs)));
+		}
+	}
+	return true;
+}
+
+/// Get the function type from an overload_entry
+template<typename Entry>
+struct entry_func_type;
+
+template<typename F, typename D>
+struct entry_func_type<overload_entry<F, D>>
+{
+	using type = F;
+};
+
+/// Holds a set of overload entries
+template<typename... Entries>
+struct overload_set
+{
+	std::tuple<Entries...> entries;
+};
+
+/// V8 callback that dispatches to the matching overload (first-match-wins)
+template<typename Traits, typename OverloadSet>
+void forward_overloaded_function(v8::FunctionCallbackInfo<v8::Value> const& args)
+{
+	v8::Isolate* isolate = args.GetIsolate();
+	v8::HandleScope scope(isolate);
+
+	auto& set = external_data::get<OverloadSet>(args.Data());
+	size_t const arg_count = args.Length();
+
+	bool matched = false;
+	std::string errors;
+
+	std::apply([&](auto const&... entries)
+	{
+		// Fold: short-circuit on first match via (matched || try_one())
+		((matched || [&]
+		{
+			using Entry = std::decay_t<decltype(entries)>;
+			using F = typename entry_func_type<Entry>::type;
+
+			// Arity check
+			constexpr size_t min = overload_arg_range<Entry>::min_args;
+			constexpr size_t max = overload_arg_range<Entry>::max_args;
+			if (arg_count < min || arg_count > max)
+				return false;
+
+			// Type check
+			if (arg_count > 0 && !overload_types_match<F, Traits>(isolate, args, arg_count))
+				return false;
+
+			// Try invoking
+			try
+			{
+				matched = try_invoke_entry<Traits>(entries, args);
+				return matched;
+			}
+			catch (std::exception const& ex)
+			{
+				if (!errors.empty()) errors += "; ";
+				errors += ex.what();
+				return false;
+			}
+		}()), ...);
+	}, set.entries);
+
+	if (!matched)
+	{
+		std::string msg = "No matching overload for " + std::to_string(arg_count) + " argument(s)";
+		if (!errors.empty())
+		{
+			msg += ". Tried: " + errors;
+		}
+		args.GetReturnValue().Set(throw_ex(isolate, msg));
+	}
+}
+
+/// Helper: wrap a plain callable into overload_entry<F, void>
+template<typename F>
+auto make_overload_entry(F&& func)
+{
+	if constexpr (is_overload_entry<std::decay_t<F>>::value)
+	{
+		return std::forward<F>(func);
+	}
+	else
+	{
+		return overload_entry<std::decay_t<F>, void>{std::forward<F>(func)};
+	}
+}
+
+} // namespace v8pp::detail
+
+namespace v8pp {
+
+/// Wrap multiple overloaded functions into a single V8 function template
+template<typename Traits = raw_ptr_traits, typename... Funcs>
+v8::Local<v8::FunctionTemplate> wrap_overload_template(v8::Isolate* isolate, Funcs&&... funcs)
+{
+	using Set = detail::overload_set<decltype(detail::make_overload_entry(std::forward<Funcs>(funcs)))...>;
+	Set set{std::make_tuple(detail::make_overload_entry(std::forward<Funcs>(funcs))...)};
+	return v8::FunctionTemplate::New(isolate,
+		&detail::forward_overloaded_function<Traits, Set>,
+		detail::external_data::set(isolate, std::move(set)),
+		v8::Local<v8::Signature>(), 0,
+		v8::ConstructorBehavior::kAllow,
+		v8::SideEffectType::kHasSideEffect);
+}
+
+/// Wrap multiple overloaded functions into a single V8 function
+template<typename Traits = raw_ptr_traits, typename... Funcs>
+v8::Local<v8::Function> wrap_overload(v8::Isolate* isolate, std::string_view name, Funcs&&... funcs)
+{
+	using Set = detail::overload_set<decltype(detail::make_overload_entry(std::forward<Funcs>(funcs)))...>;
+	Set set{std::make_tuple(detail::make_overload_entry(std::forward<Funcs>(funcs))...)};
+	v8::Local<v8::Function> fn;
+	if (!v8::Function::New(isolate->GetCurrentContext(),
+		&detail::forward_overloaded_function<Traits, Set>,
+		detail::external_data::set(isolate, std::move(set)),
+		0, v8::ConstructorBehavior::kAllow,
+		v8::SideEffectType::kHasSideEffect).ToLocal(&fn))
+	{
+		return {};
+	}
+	if (!name.empty())
+	{
+		fn->SetName(to_v8_name(isolate, name));
+	}
+	return fn;
+}
+
+} // namespace v8pp

--- a/v8pp/promise.hpp
+++ b/v8pp/promise.hpp
@@ -1,0 +1,176 @@
+#pragma once
+
+#include <string_view>
+
+#include <v8.h>
+
+#include "v8pp/convert.hpp"
+#include "v8pp/throw_ex.hpp"
+
+namespace v8pp {
+
+/// Synchronous promise wrapper around v8::Promise::Resolver.
+/// Resolve/reject must be called on the isolate's thread.
+///
+/// Usage:
+///   v8pp::promise<int> make_value(v8::Isolate* isolate) {
+///       v8pp::promise<int> p(isolate);
+///       p.resolve(42);
+///       return p;
+///   }
+///   module.function("makeValue", &make_value);
+template<typename T>
+class promise
+{
+public:
+	explicit promise(v8::Isolate* isolate)
+		: isolate_(isolate)
+	{
+		v8::HandleScope scope(isolate);
+		v8::Local<v8::Context> context = isolate->GetCurrentContext();
+		v8::Local<v8::Promise::Resolver> resolver =
+			v8::Promise::Resolver::New(context).ToLocalChecked();
+		resolver_.Reset(isolate, resolver);
+	}
+
+	promise(promise const&) = delete;
+	promise& operator=(promise const&) = delete;
+
+	promise(promise&&) = default;
+	promise& operator=(promise&&) = default;
+
+	/// Resolve the promise with a C++ value (converted to V8 via convert<T>)
+	void resolve(T const& value)
+	{
+		v8::HandleScope scope(isolate_);
+		v8::Local<v8::Context> context = isolate_->GetCurrentContext();
+		v8::Local<v8::Promise::Resolver> resolver = to_local(isolate_, resolver_);
+		resolver->Resolve(context, v8pp::to_v8(isolate_, value)).FromJust();
+	}
+
+	/// Reject the promise with an error message (creates a JS Error)
+	void reject(std::string_view message)
+	{
+		v8::HandleScope scope(isolate_);
+		v8::Local<v8::Context> context = isolate_->GetCurrentContext();
+		v8::Local<v8::Promise::Resolver> resolver = to_local(isolate_, resolver_);
+		v8::Local<v8::Value> error = v8::Exception::Error(
+			v8pp::to_v8(isolate_, message));
+		resolver->Reject(context, error).FromJust();
+	}
+
+	/// Reject the promise with a raw V8 value
+	void reject(v8::Local<v8::Value> value)
+	{
+		v8::HandleScope scope(isolate_);
+		v8::Local<v8::Context> context = isolate_->GetCurrentContext();
+		v8::Local<v8::Promise::Resolver> resolver = to_local(isolate_, resolver_);
+		resolver->Reject(context, value).FromJust();
+	}
+
+	/// Get the underlying v8::Promise (the "thenable" JS object)
+	v8::Local<v8::Promise> get_promise() const
+	{
+		v8::EscapableHandleScope scope(isolate_);
+		v8::Local<v8::Promise::Resolver> resolver = to_local(isolate_, resolver_);
+		return scope.Escape(resolver->GetPromise());
+	}
+
+	v8::Isolate* isolate() const { return isolate_; }
+
+private:
+	v8::Isolate* isolate_;
+	v8::Global<v8::Promise::Resolver> resolver_;
+};
+
+/// Specialization for void promises (signal-only, no value)
+template<>
+class promise<void>
+{
+public:
+	explicit promise(v8::Isolate* isolate)
+		: isolate_(isolate)
+	{
+		v8::HandleScope scope(isolate);
+		v8::Local<v8::Context> context = isolate->GetCurrentContext();
+		v8::Local<v8::Promise::Resolver> resolver =
+			v8::Promise::Resolver::New(context).ToLocalChecked();
+		resolver_.Reset(isolate, resolver);
+	}
+
+	promise(promise const&) = delete;
+	promise& operator=(promise const&) = delete;
+
+	promise(promise&&) = default;
+	promise& operator=(promise&&) = default;
+
+	/// Resolve the void promise (with undefined)
+	void resolve()
+	{
+		v8::HandleScope scope(isolate_);
+		v8::Local<v8::Context> context = isolate_->GetCurrentContext();
+		v8::Local<v8::Promise::Resolver> resolver = to_local(isolate_, resolver_);
+		resolver->Resolve(context, v8::Undefined(isolate_)).FromJust();
+	}
+
+	/// Reject the promise with an error message (creates a JS Error)
+	void reject(std::string_view message)
+	{
+		v8::HandleScope scope(isolate_);
+		v8::Local<v8::Context> context = isolate_->GetCurrentContext();
+		v8::Local<v8::Promise::Resolver> resolver = to_local(isolate_, resolver_);
+		v8::Local<v8::Value> error = v8::Exception::Error(
+			v8pp::to_v8(isolate_, message));
+		resolver->Reject(context, error).FromJust();
+	}
+
+	/// Reject the promise with a raw V8 value
+	void reject(v8::Local<v8::Value> value)
+	{
+		v8::HandleScope scope(isolate_);
+		v8::Local<v8::Context> context = isolate_->GetCurrentContext();
+		v8::Local<v8::Promise::Resolver> resolver = to_local(isolate_, resolver_);
+		resolver->Reject(context, value).FromJust();
+	}
+
+	/// Get the underlying v8::Promise (the "thenable" JS object)
+	v8::Local<v8::Promise> get_promise() const
+	{
+		v8::EscapableHandleScope scope(isolate_);
+		v8::Local<v8::Promise::Resolver> resolver = to_local(isolate_, resolver_);
+		return scope.Escape(resolver->GetPromise());
+	}
+
+	v8::Isolate* isolate() const { return isolate_; }
+
+private:
+	v8::Isolate* isolate_;
+	v8::Global<v8::Promise::Resolver> resolver_;
+};
+
+// Exclude promise<T> from is_wrapped_class so the convert system doesn't
+// try to unwrap it as a bound C++ class
+template<typename T>
+struct is_wrapped_class<promise<T>> : std::false_type
+{
+};
+
+/// convert<promise<T>> — to_v8 returns the JS promise object
+template<typename T>
+struct convert<promise<T>>
+{
+	using from_type = promise<T>;
+	using to_type = v8::Local<v8::Promise>;
+
+	static bool is_valid(v8::Isolate*, v8::Local<v8::Value> value)
+	{
+		return !value.IsEmpty() && value->IsPromise();
+	}
+
+	static to_type to_v8(v8::Isolate*, promise<T> const& value)
+	{
+		return value.get_promise();
+	}
+};
+
+} // namespace v8pp

--- a/v8pp/type_info.hpp
+++ b/v8pp/type_info.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "v8pp/config.hpp"
+
 #include <string_view>
 #include <cstdint>
 
@@ -59,7 +61,7 @@ inline type_info type_id()
 #else
 #error "Unknown compiler"
 #endif
-#if V8PP_PRETTIFY_TYPENAMES == 1
+#if V8PP_PRETTIFY_TYPENAMES
 	for (auto&& prefix : all_prefixes)
 	{
 		const auto p = name.find(prefix);

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <concepts>
 #include <functional>
 #include <memory>
@@ -125,6 +126,75 @@ struct is_array<std::array<T, N>> : std::true_type
 {
 	static constexpr size_t length = N;
 };
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// is_set<T> — set-like containers (insert but not emplace_back)
+//
+template<typename T>
+concept set_like = !is_string<T>::value && !mapping<T> && !sequence<T>
+	&& requires(T t, typename T::value_type v) {
+		t.begin();
+		t.end();
+		t.insert(std::move(v));
+	};
+
+template<typename T>
+struct is_set : std::bool_constant<set_like<T>>
+{
+};
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// is_pair<T>
+//
+template<typename T>
+struct is_pair : std::false_type
+{
+};
+
+template<typename K, typename V>
+struct is_pair<std::pair<K, V>> : std::true_type
+{
+};
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// is_duration<T>
+//
+template<typename T>
+struct is_duration : std::false_type
+{
+};
+
+template<typename Rep, typename Period>
+struct is_duration<std::chrono::duration<Rep, Period>> : std::true_type
+{
+};
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// is_time_point<T>
+//
+template<typename T>
+struct is_time_point : std::false_type
+{
+};
+
+template<typename Clock, typename Duration>
+struct is_time_point<std::chrono::time_point<Clock, Duration>> : std::true_type
+{
+};
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// typed_array_trait<T> — maps C++ types to V8 TypedArray types
+//
+template<typename T>
+struct typed_array_trait;
+
+template<typename T>
+concept typed_array_element = requires { typename typed_array_trait<T>::type; };
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -314,4 +314,12 @@ concept callable = std::is_function_v<std::remove_pointer_t<F>>
 template<typename F>
 using is_callable = std::bool_constant<callable<F>>;
 
+template<typename F>
+inline constexpr bool is_const_member_function_v = false;
+
+template<typename F>
+	requires std::is_member_function_pointer_v<F>
+inline constexpr bool is_const_member_function_v<F> =
+	std::is_const_v<typename function_traits<F>::class_type>;
+
 } // namespace v8pp::detail


### PR DESCRIPTION
## v3.0.0 Changelog

### V8 Compatibility
- Bump minimum supported V8 to 9.0+
- Fix V8 12.9+ API: SetAccessor → SetNativeDataProperty, FastApiCallbackOptions changes
- Convert int64/uint64 to Number instead of BigInt for JS arithmetic compatibility
- Fix script-reachable ToLocalChecked crashes (Proxy traps, ToString)

### C++20 Modernization
- Replace SFINAE enable_if with C++20 concepts (mapping, sequence, set_like, callable, etc.)
- Deduplicate object.hpp subobject traversal using concepts

### New Type Conversions
- BigInt (input), std::span → TypedArray, std::vector<uint8_t> → ArrayBuffer
- std::set/unordered_set, std::pair, std::filesystem::path
- std::chrono::duration and time_point (milliseconds / epoch ms)

### New Binding Features
- Function overloading with runtime argument dispatch
- Default parameters via v8pp::defaults() (fills from right)
- V8 Fast API callbacks (V8 10+) for supported signatures
- Symbol protocols: Symbol.toStringTag, Symbol.toPrimitive
- Iterator protocol: Symbol.iterator with begin/end binding
- v8pp::promise<T> synchronous wrapper around v8::Promise::Resolver
- v8pp::context_store for cross-context key-value persistence

### Safety & Robustness
- add try_from_v8<T> exception-free conversion returning std::optional
- unwrap_object prototype chain depth limit (16) to prevent infinite loops
- Magic number validation (0xC1A5517F) on object_registry before static_cast
- Use-after-free protection in context::require() via weak pointer
- Null checks on unwrap_object in property/member accessors

### Performance
- SideEffectType annotations on read-only accessors
- Internalized strings for repeated property names
- NewFromUtf8Literal for compile-time string constants

### Build & CI
- Modernize CMake configuration and CI workflow (Ubuntu, macOS, Windows matrix)
- Add BUILD_BENCHMARKS option
- Add CUSTOM_V8_LIB_PATH for custom V8 builds
- Fix NuGet cache missing V8 redist DLLs on Windows
- Fix V8PP_PRETTIFY_TYPENAMES config propagation
- Fix alive_contexts thread safety

### Tests
- Expanded test suite: adversarial inputs, GC stress, thread safety
- Crash safety tests for invalid from_v8 inputs, circular JSON, non-wrapped objects
- Fix constructor-without-new crash

### Docs
- Update README to reflect fork state and features
- Add CLAUDE.md project guide