### PR TITLE
modernize CMake target setup for clean embedding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,14 @@ project(v8pp
 	LANGUAGES CXX
 )
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# The C++ standard and /Zc:__cplusplus are requirements of the v8pp target
+# itself (target_compile_features / target_compile_options in v8pp/CMakeLists.txt),
+# not global state. Consuming v8pp via add_subdirectory therefore leaves the
+# parent project's own standard and flags untouched.
 
 if (MSVC)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus") # enable correct __cplusplus macro
 	# static CRT when using a custom V8 monolith built with /MT
-	if(DEFINED CUSTOM_V8_LIB_PATH)
+	if(DEFINED CUSTOM_V8_LIB_PATH OR DEFINED CUSTOM_V8_LIB_PATH_ABS)
 		set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 	endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Tested on:
 - Concepts replace SFINAE for type dispatch (`mapping`, `sequence`, `set_like`, `callable`, etc.)
 - Dead V8 < 9.0 code paths removed
 
+**Build system**
+- Uses no `typeid`/`dynamic_cast`; the compiled library is built RTTI-free (`-fno-rtti` / `/GR-`) to match V8's default ABI
+- Build flags (RTTI, warning level, exception model) are scoped `PRIVATE`; only the C++20 requirement and V8 ABI defines are public, so consumers are never forced to adopt v8pp's build choices
+- No global CMake state is set, so embedding via `add_subdirectory` leaves the parent project's standard and flags untouched
+
 ## Building and testing
 
 The library has a set of tests that can be configured, built, and run with CMake:

--- a/v8pp/CMakeLists.txt
+++ b/v8pp/CMakeLists.txt
@@ -4,29 +4,41 @@ include(GNUInstallDirs)
 
 if(TARGET V8::V8)
 	message(STATUS "Using existing V8::V8 target")
-elseif(DEFINED CUSTOM_V8_LIB_PATH)
+elseif(DEFINED CUSTOM_V8_LIB_PATH OR DEFINED CUSTOM_V8_LIB_PATH_ABS)
+	# Resolve effective paths (_ABS = absolute, plain = relative as-is)
+	if(DEFINED CUSTOM_V8_INCLUDE_PATH_ABS)
+		set(_v8pp_inc "${CUSTOM_V8_INCLUDE_PATH_ABS}")
+	elseif(DEFINED CUSTOM_V8_INCLUDE_PATH)
+		set(_v8pp_inc "${CUSTOM_V8_INCLUDE_PATH}")
+	endif()
+	if(DEFINED CUSTOM_V8_LIB_PATH_ABS)
+		set(_v8pp_lib "${CUSTOM_V8_LIB_PATH_ABS}")
+	else()
+		set(_v8pp_lib "${CUSTOM_V8_LIB_PATH}")
+	endif()
+
 	add_library(CustomV8 INTERFACE)
 	add_library(V8::V8 ALIAS CustomV8)
-	if(DEFINED CUSTOM_V8_INCLUDE_PATH)
+	if(DEFINED _v8pp_inc)
 		target_include_directories(CustomV8 INTERFACE
-			$<BUILD_INTERFACE:${CUSTOM_V8_INCLUDE_PATH}>
+			$<BUILD_INTERFACE:${_v8pp_inc}>
 		)
 	endif()
-	get_filename_component(_v8_ext "${CUSTOM_V8_LIB_PATH}" EXT)
+	get_filename_component(_v8_ext "${_v8pp_lib}" EXT)
 	if("${_v8_ext}" STREQUAL ".a" OR "${_v8_ext}" STREQUAL ".so" OR "${_v8_ext}" STREQUAL ".lib" OR "${_v8_ext}" STREQUAL ".dylib")
-		target_link_libraries(CustomV8 INTERFACE "${CUSTOM_V8_LIB_PATH}")
+		target_link_libraries(CustomV8 INTERFACE "${_v8pp_lib}")
 	else()
 		# directory containing individual V8 static libs
 		target_link_libraries(CustomV8 INTERFACE
-			"${CUSTOM_V8_LIB_PATH}/libv8_libbase.a"
-			"${CUSTOM_V8_LIB_PATH}/libv8_libplatform.a"
-			"${CUSTOM_V8_LIB_PATH}/libv8_monolith.a"
+			"${_v8pp_lib}/libv8_libbase.a"
+			"${_v8pp_lib}/libv8_libplatform.a"
+			"${_v8pp_lib}/libv8_monolith.a"
 		)
 	endif()
 	if(WIN32)
 		target_link_libraries(CustomV8 INTERFACE winmm dbghelp)
 	endif()
-	message(STATUS "Using custom V8 from ${CUSTOM_V8_LIB_PATH}")
+	message(STATUS "Using custom V8 from ${_v8pp_lib}")
 elseif(DEFINED VCPKG_TARGET_TRIPLET)
 	find_package(V8 CONFIG REQUIRED)
 else()
@@ -90,20 +102,24 @@ else()
 	)
 endif()
 
+# Flags for compiling v8pp's own sources. Applied PRIVATE below so they never
+# propagate to consumers: RTTI, warning levels and exception model are build
+# choices, not usage requirements. v8pp uses no typeid/dynamic_cast, so it is
+# built RTTI-off to match V8's -fno-rtti ABI, consistent with the MSVC /GR-.
 if(MSVC)
-	set(V8PP_COMPILE_OPTIONS /GR- /EHsc /permissive- /W4)
+	set(V8PP_COMPILE_OPTIONS /GR- /EHsc /permissive- /W4 /Zc:__cplusplus)
 	# disable specific warnings
 	list(APPEND V8PP_COMPILE_OPTIONS /wd4190)
 	# set warning level 3 for system headers
 	list(APPEND V8PP_COMPILE_OPTIONS /external:anglebrackets /external:W3)
 else()
-	set(V8PP_COMPILE_OPTIONS -frtti -fexceptions -Wall -Wextra -Wpedantic)
+	set(V8PP_COMPILE_OPTIONS -fno-rtti -fexceptions -Wall -Wextra -Wpedantic)
 endif()
 
 if(V8PP_HEADER_ONLY)
 	add_library(v8pp INTERFACE)
+	target_compile_features(v8pp INTERFACE cxx_std_20)
 	target_compile_definitions(v8pp INTERFACE ${V8PP_DEFINES})
-	target_compile_options(v8pp INTERFACE ${V8PP_COMPILE_OPTIONS})
 	target_include_directories(v8pp INTERFACE
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
 		$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
@@ -111,8 +127,15 @@ if(V8PP_HEADER_ONLY)
 	target_link_libraries(v8pp INTERFACE V8::V8)
 else()
 	add_library(v8pp ${V8PP_HEADERS} ${V8PP_SOURCES})
+	# Consumers need at least C++20; v8pp's own sources are pinned to C++20 so
+	# they build identically regardless of the consumer's (possibly newer) standard.
+	target_compile_features(v8pp PUBLIC cxx_std_20)
+	set_target_properties(v8pp PROPERTIES
+		CXX_STANDARD 20
+		CXX_STANDARD_REQUIRED ON
+		CXX_EXTENSIONS OFF)
 	target_compile_definitions(v8pp PUBLIC ${V8PP_DEFINES})
-	target_compile_options(v8pp PUBLIC ${V8PP_COMPILE_OPTIONS})
+	target_compile_options(v8pp PRIVATE ${V8PP_COMPILE_OPTIONS})
 	target_include_directories(v8pp PUBLIC
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
 		$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
@@ -123,25 +146,27 @@ else()
 	endif()
 endif()
 
-# Install
-include(CMakePackageConfigHelpers)
+# Install (skipped when consumed as a subdirectory of another package)
+if(NOT V8PP_SKIP_INSTALL)
+	include(CMakePackageConfigHelpers)
 
-set(targets_export_name v8pp_Targets)
+	set(targets_export_name v8pp_Targets)
 
-write_basic_package_version_file("${PROJECT_BINARY_DIR}/ConfigVersion.cmake" COMPATIBILITY SameMajorVersion)
-configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in" "${PROJECT_BINARY_DIR}/Config.cmake"
-	INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/v8pp/cmake)
+	write_basic_package_version_file("${PROJECT_BINARY_DIR}/ConfigVersion.cmake" COMPATIBILITY SameMajorVersion)
+	configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in" "${PROJECT_BINARY_DIR}/Config.cmake"
+		INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/v8pp/cmake)
 
-if(TARGET CustomV8)
-	install(TARGETS CustomV8 EXPORT ${targets_export_name})
+	if(TARGET CustomV8)
+		install(TARGETS CustomV8 EXPORT ${targets_export_name})
+	endif()
+	install(TARGETS v8pp EXPORT ${targets_export_name})
+	install(EXPORT ${targets_export_name}
+		NAMESPACE v8pp::
+		FILE ${targets_export_name}.cmake
+		DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/v8pp")
+
+	install(FILES "${PROJECT_BINARY_DIR}/ConfigVersion.cmake" "${PROJECT_BINARY_DIR}/Config.cmake"
+		DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/v8pp")
+
+	install(FILES ${V8PP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/v8pp)
 endif()
-install(TARGETS v8pp EXPORT ${targets_export_name})
-install(EXPORT ${targets_export_name}
-	NAMESPACE v8pp::
-	FILE ${targets_export_name}.cmake
-	DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/v8pp")
-
-install(FILES "${PROJECT_BINARY_DIR}/ConfigVersion.cmake" "${PROJECT_BINARY_DIR}/Config.cmake"
-	DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/v8pp")
-
-install(FILES ${V8PP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/v8pp)


### PR DESCRIPTION
- Scope build flags (RTTI, warnings, /EHsc) PRIVATE so v8pp's build choices no longer propagate to consumers; keep only the V8 ABI defines and the C++20 requirement public
- Build RTTI-free (-fno-rtti / /GR-): v8pp uses no typeid/dynamic_cast, so this matches V8's -fno-rtti ABI and removes the consumer/V8 typeinfo conflict that broke -fno-rtti subclasses of V8 base types
- Express the standard via target_compile_features(cxx_std_20) and pin v8pp's own sources to C++20, replacing global CMAKE_CXX_* state; move /Zc:__cplusplus to the target's private MSVC options
- Accept absolute custom-V8 paths (CUSTOM_V8_*_ABS) and skip the standalone install when embedded (V8PP_SKIP_INSTALL)
- Document the build-system behavior in README